### PR TITLE
Adds readthedocs config yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "latest"
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  # Fail on all warnings to avoid broken references
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc


### PR DESCRIPTION
Mainly, adding our ReadTheDocs yaml config file to get that setup.

Included:
  - Using Ubuntu 22.04 + Python 3.12 (@Lance-Drane let me know if those need to change; I'm just using the defaults)
  - Sphinx setup to use our `docs/conf.py` and fail on warnings if we have broken links (I thought that sounded like a good check!)
  - Use `pip install .[doc]` command to install the package + our docs requirements (mainly `furo` theme)