### PR TITLE
Fix for ReadTheDocs dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,4 +18,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - doc
+        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ amqp = [
 py38 = [
     "eval-type-backport>=0.1.3",
 ]
+docs = [
+    "sphinx>=5.3.0",
+    "furo>=2023.3.27",
+]
 
 [tool.pdm.dev-dependencies]
 lint = [
@@ -57,12 +61,7 @@ test = [
     "pytest-cov>=4.1.0",
     "httpretty>=1.1.4",
 ]
-doc = [
-    "sphinx>=5.3.0",
-    "furo>=2023.3.27",
-]
-":lint" = [
-]
+
 
 [tool.pdm.scripts]
 test-all = "pytest tests/ --cov=src/intersect_sdk/ --cov-fail-under=80 --cov-report=html:reports/htmlcov/ --cov-report=xml:reports/coverage_report.xml --junitxml=reports/junit.xml"


### PR DESCRIPTION
The issue:
  - we have the docs deps under PDM dev deps; this is not accessible via [readthedocs extra requirements install](https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install)
  - Instead, moving the docs deps to "optional dependencies" in `pyproject.toml`; was able to use `pip install .[docs]` locally and get furo theme in my environment :+1: 
  - Did switch the name of the docs deps from `doc` -> `docs`