### PR TITLE
amqp unsub routine now works, make broker logic more robust

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "15672:15672" # Web UI
     environment:
       # full list of env variables available at https://github.com/bitnami/containers/blob/main/bitnami/rabbitmq/README.md
-      RABBITMQ_PLUGINS: "rabbitmq_mqtt"
+      RABBITMQ_PLUGINS: "rabbitmq_management rabbitmq_mqtt"
       RABBITMQ_USERNAME: "intersect_username"
       RABBITMQ_PASSWORD: "intersect_password"
       RABBITMQ_MANAGEMENT_ALLOW_WEB_ACCESS: "yes"

--- a/examples/1_hello_world_amqp/hello_client.py
+++ b/examples/1_hello_world_amqp/hello_client.py
@@ -10,6 +10,7 @@ from intersect_sdk import (
 )
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger('pika').setLevel(logging.WARNING)
 
 
 def simple_client_callback(

--- a/examples/1_hello_world_amqp/hello_service.py
+++ b/examples/1_hello_world_amqp/hello_service.py
@@ -11,6 +11,7 @@ from intersect_sdk import (
 )
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger('pika').setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 

--- a/examples/3_ping_pong_events_amqp/ping_pong_client.py
+++ b/examples/3_ping_pong_events_amqp/ping_pong_client.py
@@ -1,0 +1,99 @@
+import logging
+
+from intersect_sdk import (
+    INTERSECT_JSON_VALUE,
+    IntersectClient,
+    IntersectClientCallback,
+    IntersectClientConfig,
+    default_intersect_lifecycle_loop,
+)
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger('pika').setLevel(logging.WARNING)
+
+logger = logging.getLogger(__name__)
+
+PING_SERVICE = 'p-ng-organization.p-ng-facility.p-ng-system.p-ng-subsystem.ping-service'
+PONG_SERVICE = 'p-ng-organization.p-ng-facility.p-ng-system.p-ng-subsystem.pong-service'
+
+
+class SampleOrchestrator:
+    """Basic orchestrator with an event callback.
+
+    The event callback switches between listening to 'ping' and 'pong' events; it never listens to both simultaneously.
+    """
+
+    MAX_EVENTS_TO_PROCESS = 4
+
+    def __init__(self) -> None:
+        """Straightforward constructor, just initializes global variable which counts events."""
+        self.events_encountered = 0
+
+    def event_callback(
+        self, _source: str, _operation: str, event_name: str, payload: INTERSECT_JSON_VALUE
+    ) -> IntersectClientCallback:
+        """Handles events from two Services at once.
+
+        With this handler, the order of instructions goes like this:
+
+        1. Listen for a ping event.
+        2. On ping event - Start listening for pong events and stop listening for ping events.
+        3. On pong event - Start listening for ping events and stop listening for pong events.
+        4. Repeat steps 2-3 until we have processed the maximum number of events we want to.
+        """
+        self.events_encountered += 1
+        logger.info(payload)
+        print(payload)
+        if self.events_encountered == self.MAX_EVENTS_TO_PROCESS:
+            raise Exception
+
+        # we would normally also check the source here. With certain services, checking the operation can also be helpful.
+        if event_name == 'ping':
+            return IntersectClientCallback(
+                services_to_start_listening_for_events=[PONG_SERVICE],
+                services_to_stop_listening_for_events=[PING_SERVICE],
+            )
+        return IntersectClientCallback(
+            services_to_start_listening_for_events=[PING_SERVICE],
+            services_to_stop_listening_for_events=[PONG_SERVICE],
+        )
+
+
+if __name__ == '__main__':
+    from_config_file = {
+        'data_stores': {
+            'minio': [
+                {
+                    'username': 'AKIAIOSFODNN7EXAMPLE',
+                    'password': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+                    'port': 9000,
+                },
+            ],
+        },
+        'brokers': [
+            {
+                'username': 'intersect_username',
+                'password': 'intersect_password',
+                'port': 5672,
+                'protocol': 'amqp0.9.1',
+            },
+        ],
+    }
+
+    # we initially only listen for ping service events,
+    config = IntersectClientConfig(
+        initial_message_event_config=IntersectClientCallback(
+            services_to_start_listening_for_events=[
+                PING_SERVICE,
+            ]
+        ),
+        **from_config_file,
+    )
+    orchestrator = SampleOrchestrator()
+    client = IntersectClient(
+        config=config,
+        event_callback=orchestrator.event_callback,
+    )
+    default_intersect_lifecycle_loop(
+        client,
+    )

--- a/examples/3_ping_pong_events_amqp/ping_service.py
+++ b/examples/3_ping_pong_events_amqp/ping_service.py
@@ -1,0 +1,36 @@
+"""Simple service which regularly emits an event."""
+
+import logging
+import threading
+import time
+
+from intersect_sdk import IntersectEventDefinition, intersect_event
+
+from .service_runner import P_ngBaseCapabilityImplementation, run_service
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger('pika').setLevel(logging.WARNING)
+
+
+class PingCapabiilityImplementation(P_ngBaseCapabilityImplementation):
+    """Basic capability definition, very similar to the other capability except for the type of event it emits."""
+
+    def after_service_startup(self) -> None:
+        """Called after service startup."""
+        self.counter_thread = threading.Thread(
+            target=self.ping_event,
+            daemon=True,
+            name='counter_thread',
+        )
+        self.counter_thread.start()
+
+    @intersect_event(events={'ping': IntersectEventDefinition(event_type=str)})
+    def ping_event(self) -> None:
+        """Send out a ping event every 2 seconds."""
+        while True:
+            time.sleep(2.0)
+            self.intersect_sdk_emit_event('ping', 'ping')
+
+
+if __name__ == '__main__':
+    run_service(PingCapabiilityImplementation())

--- a/examples/3_ping_pong_events_amqp/ping_service_schema.json
+++ b/examples/3_ping_pong_events_amqp/ping_service_schema.json
@@ -1,0 +1,140 @@
+{
+  "asyncapi": "2.6.0",
+  "x-intersect-version": "0.6.2",
+  "info": {
+    "title": "p-ng-organization.p-ng-facility.p-ng-system.p-ng-subsystem.ping-service",
+    "version": "0.0.0"
+  },
+  "defaultContentType": "application/json",
+  "channels": {},
+  "events": {
+    "ping": {
+      "type": "string"
+    }
+  },
+  "components": {
+    "schemas": {},
+    "messageTraits": {
+      "commonHeaders": {
+        "messageHeaders": {
+          "$defs": {
+            "IntersectDataHandler": {
+              "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+              "enum": [
+                0,
+                1
+              ],
+              "title": "IntersectDataHandler",
+              "type": "integer"
+            }
+          },
+          "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+          "properties": {
+            "source": {
+              "description": "source of the message",
+              "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+              "title": "Source",
+              "type": "string"
+            },
+            "destination": {
+              "description": "destination of the message",
+              "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+              "title": "Destination",
+              "type": "string"
+            },
+            "created_at": {
+              "description": "the UTC timestamp of message creation",
+              "format": "date-time",
+              "title": "Created At",
+              "type": "string"
+            },
+            "sdk_version": {
+              "description": "SemVer string of SDK's version, used to check for compatibility",
+              "pattern": "^\\d+\\.\\d+\\.\\d+$",
+              "title": "Sdk Version",
+              "type": "string"
+            },
+            "data_handler": {
+              "allOf": [
+                {
+                  "$ref": "#/components/messageTraits/commonHeaders/userspaceHeaders/$defs/IntersectDataHandler"
+                }
+              ],
+              "default": 0,
+              "description": "Code signifying where data is stored."
+            },
+            "has_error": {
+              "default": false,
+              "description": "If this value is True, the payload will contain the error message (a string)",
+              "title": "Has Error",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "source",
+            "destination",
+            "created_at",
+            "sdk_version"
+          ],
+          "title": "UserspaceMessageHeader",
+          "type": "object"
+        },
+        "eventHeaders": {
+          "$defs": {
+            "IntersectDataHandler": {
+              "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+              "enum": [
+                0,
+                1
+              ],
+              "title": "IntersectDataHandler",
+              "type": "integer"
+            }
+          },
+          "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+          "properties": {
+            "source": {
+              "description": "source of the message",
+              "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+              "title": "Source",
+              "type": "string"
+            },
+            "created_at": {
+              "description": "the UTC timestamp of message creation",
+              "format": "date-time",
+              "title": "Created At",
+              "type": "string"
+            },
+            "sdk_version": {
+              "description": "SemVer string of SDK's version, used to check for compatibility",
+              "pattern": "^\\d+\\.\\d+\\.\\d+$",
+              "title": "Sdk Version",
+              "type": "string"
+            },
+            "data_handler": {
+              "allOf": [
+                {
+                  "$ref": "#/components/messageTraits/commonHeaders/eventHeaders/$defs/IntersectDataHandler"
+                }
+              ],
+              "default": 0,
+              "description": "Code signifying where data is stored."
+            },
+            "event_name": {
+              "title": "Event Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "created_at",
+            "sdk_version",
+            "event_name"
+          ],
+          "title": "EventMessageHeaders",
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/examples/3_ping_pong_events_amqp/pong_service.py
+++ b/examples/3_ping_pong_events_amqp/pong_service.py
@@ -1,0 +1,36 @@
+"""Simple service which regularly emits an event."""
+
+import logging
+import threading
+import time
+
+from intersect_sdk import IntersectEventDefinition, intersect_event
+
+from .service_runner import P_ngBaseCapabilityImplementation, run_service
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger('pika').setLevel(logging.WARNING)
+
+
+class PongCapabiilityImplementation(P_ngBaseCapabilityImplementation):
+    """Basic capability definition, very similar to the other capability except for the type of event it emits."""
+
+    def after_service_startup(self) -> None:
+        """Called after service startup."""
+        self.counter_thread = threading.Thread(
+            target=self.pong_event,
+            daemon=True,
+            name='counter_thread',
+        )
+        self.counter_thread.start()
+
+    @intersect_event(events={'pong': IntersectEventDefinition(event_type=str)})
+    def pong_event(self) -> None:
+        """Send out a pong event every 2 seconds."""
+        while True:
+            time.sleep(2.0)
+            self.intersect_sdk_emit_event('pong', 'pong')
+
+
+if __name__ == '__main__':
+    run_service(PongCapabiilityImplementation())

--- a/examples/3_ping_pong_events_amqp/pong_service_schema.json
+++ b/examples/3_ping_pong_events_amqp/pong_service_schema.json
@@ -1,0 +1,140 @@
+{
+  "asyncapi": "2.6.0",
+  "x-intersect-version": "0.6.2",
+  "info": {
+    "title": "p-ng-organization.p-ng-facility.p-ng-system.p-ng-subsystem.pong-service",
+    "version": "0.0.0"
+  },
+  "defaultContentType": "application/json",
+  "channels": {},
+  "events": {
+    "pong": {
+      "type": "string"
+    }
+  },
+  "components": {
+    "schemas": {},
+    "messageTraits": {
+      "commonHeaders": {
+        "messageHeaders": {
+          "$defs": {
+            "IntersectDataHandler": {
+              "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+              "enum": [
+                0,
+                1
+              ],
+              "title": "IntersectDataHandler",
+              "type": "integer"
+            }
+          },
+          "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+          "properties": {
+            "source": {
+              "description": "source of the message",
+              "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+              "title": "Source",
+              "type": "string"
+            },
+            "destination": {
+              "description": "destination of the message",
+              "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+              "title": "Destination",
+              "type": "string"
+            },
+            "created_at": {
+              "description": "the UTC timestamp of message creation",
+              "format": "date-time",
+              "title": "Created At",
+              "type": "string"
+            },
+            "sdk_version": {
+              "description": "SemVer string of SDK's version, used to check for compatibility",
+              "pattern": "^\\d+\\.\\d+\\.\\d+$",
+              "title": "Sdk Version",
+              "type": "string"
+            },
+            "data_handler": {
+              "allOf": [
+                {
+                  "$ref": "#/components/messageTraits/commonHeaders/userspaceHeaders/$defs/IntersectDataHandler"
+                }
+              ],
+              "default": 0,
+              "description": "Code signifying where data is stored."
+            },
+            "has_error": {
+              "default": false,
+              "description": "If this value is True, the payload will contain the error message (a string)",
+              "title": "Has Error",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "source",
+            "destination",
+            "created_at",
+            "sdk_version"
+          ],
+          "title": "UserspaceMessageHeader",
+          "type": "object"
+        },
+        "eventHeaders": {
+          "$defs": {
+            "IntersectDataHandler": {
+              "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+              "enum": [
+                0,
+                1
+              ],
+              "title": "IntersectDataHandler",
+              "type": "integer"
+            }
+          },
+          "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+          "properties": {
+            "source": {
+              "description": "source of the message",
+              "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+              "title": "Source",
+              "type": "string"
+            },
+            "created_at": {
+              "description": "the UTC timestamp of message creation",
+              "format": "date-time",
+              "title": "Created At",
+              "type": "string"
+            },
+            "sdk_version": {
+              "description": "SemVer string of SDK's version, used to check for compatibility",
+              "pattern": "^\\d+\\.\\d+\\.\\d+$",
+              "title": "Sdk Version",
+              "type": "string"
+            },
+            "data_handler": {
+              "allOf": [
+                {
+                  "$ref": "#/components/messageTraits/commonHeaders/eventHeaders/$defs/IntersectDataHandler"
+                }
+              ],
+              "default": 0,
+              "description": "Code signifying where data is stored."
+            },
+            "event_name": {
+              "title": "Event Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "created_at",
+            "sdk_version",
+            "event_name"
+          ],
+          "title": "EventMessageHeaders",
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/examples/3_ping_pong_events_amqp/service_runner.py
+++ b/examples/3_ping_pong_events_amqp/service_runner.py
@@ -1,0 +1,71 @@
+"""Common functionality between all of the Service classes."""
+
+import logging
+from abc import ABC, abstractmethod
+
+from intersect_sdk import (
+    HierarchyConfig,
+    IntersectBaseCapabilityImplementation,
+    IntersectService,
+    IntersectServiceConfig,
+    default_intersect_lifecycle_loop,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class P_ngBaseCapabilityImplementation(IntersectBaseCapabilityImplementation, ABC):  # noqa: N801
+    """Common interface definitions, no implementations here."""
+
+    @abstractmethod
+    def after_service_startup(self) -> None:
+        """Common function implemented by the various P-NG capabilities after the service starts up."""
+
+
+def run_service(capability: P_ngBaseCapabilityImplementation) -> None:
+    """The idea behind the two services is that each one will emit a unique event.
+
+    The interesting configuration mostly happens in the Client, look at that one for details.
+    """
+    from_config_file = {
+        'data_stores': {
+            'minio': [
+                {
+                    'username': 'AKIAIOSFODNN7EXAMPLE',
+                    'password': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+                    'port': 9000,
+                },
+            ],
+        },
+        'brokers': [
+            {
+                'username': 'intersect_username',
+                'password': 'intersect_password',
+                'port': 5672,
+                'protocol': 'amqp0.9.1',
+            },
+        ],
+    }
+    service_name = capability.__class__.__name__[:4].lower()
+    config = IntersectServiceConfig(
+        hierarchy=HierarchyConfig(
+            organization='p-ng-organization',
+            facility='p-ng-facility',
+            system='p-ng-system',
+            subsystem='p-ng-subsystem',
+            service=f'{service_name}-service',
+        ),
+        status_interval=30.0,
+        **from_config_file,
+    )
+    service = IntersectService(capability, config)
+    logger.info('Starting %s_service, use Ctrl+C to exit.', service_name)
+
+    """
+    Here, we provide the after_service_startup function on the capability as a post startup callback.
+
+    This ensures we don't emit any events until we've actually started up our Service.
+    """
+    default_intersect_lifecycle_loop(
+        service, post_startup_callback=capability.after_service_startup
+    )

--- a/src/intersect_sdk/_internal/control_plane/brokers/amqp_client.py
+++ b/src/intersect_sdk/_internal/control_plane/brokers/amqp_client.py
@@ -1,21 +1,65 @@
+"""This module handles ALL AMQP protocol logic in INTERSECT. We seek to entirely abstract protocols away from users.
+
+This is a very specific pub-sub model which assumes a single topic exchange.
+AMQP topics in INTERSECT generally look like ${ORGANIZATION}.${HIERARCHY}.${SYSTEM}.${SUBSYSTEM}.${SERVICE}.${MESSAGE_TYPE} .
+MESSAGE_TYPE refers to INTERSECT domain messages - we do not allow users to determine their own message types directly, and every message has a message type.
+SERVICE refers to a specific application.
+SYSTEM is generally the level where Auth should occur, and where you should configure access control on the broker itself.
+"""
+
 from __future__ import annotations
 
 import functools
 import threading
-import uuid
+import time
+from hashlib import sha384
 from typing import TYPE_CHECKING, Callable
 
 import pika
-from retrying import retry
+import pika.delivery_mode
+import pika.exceptions
+import pika.frame
 
+from ...logger import logger
 from .broker_client import BrokerClient
 
 if TYPE_CHECKING:
-    from collections import defaultdict
-
     from pika.channel import Channel
     from pika.frame import Frame
     from pika.spec import Basic, BasicProperties
+
+    from ..topic_handler import TopicHandler
+
+
+# Note that we deliberately do NOT want this configurable at runtime. Any two INTERSECT services/clients could potentially exchange messages between one another.
+_INTERSECT_MESSAGE_EXCHANGE = 'intersect-messages'
+"""All INTERSECT messages get published to one exchange on the broker."""
+
+
+def _get_queue_name(routing_key: str) -> str:
+    """Generate a valid queue name from the routing key.
+
+    We want to always be able to generate the same queue name from the routing key every time,
+    so we don't use UUIDs or want the broker to generate a key name.
+
+    We must also keep the length under 128 characters.
+
+    See https://www.rabbitmq.com/docs/queues#names for a complete reference.
+    """
+    return sha384(routing_key.encode()).hexdigest()
+
+
+# TODO we should be handling hierarchy parts as a list of strings until they get to the client
+# this will be a breaking change, so only add it when ready to break
+def _hierarchy_2_amqp(hierarchy: str) -> str:
+    """Take the hierarchy string format saved in the Service and map it to the AMQP topic format."""
+    return hierarchy.replace('/', '.')
+
+
+# TODO see above
+def _amqp_2_hierarchy(amqp_routing_key: str) -> str:
+    """Convert AMQP topic formats to how we store a key in the ControlPlaneManager."""
+    return amqp_routing_key.replace('.', '/')
 
 
 class AMQPClient(BrokerClient):
@@ -38,8 +82,7 @@ class AMQPClient(BrokerClient):
         port: int,
         username: str,
         password: str,
-        topics_to_handlers: Callable[[], defaultdict[str, set[Callable[[bytes], None]]]],
-        uid: str | None = None,
+        topics_to_handlers: Callable[[], dict[str, TopicHandler]],
     ) -> None:
         """The default constructor.
 
@@ -49,58 +92,56 @@ class AMQPClient(BrokerClient):
             username: username credentials for AMQP broker
             password: password credentials for AMQP broker
             topics_to_handlers: callback function which gets the topic to handler map from the channel manager
-            uid: String for the client's UUID.
         """
-        self.uid = uid if uid else str(uuid.uuid4())
-
         self._connection_params = pika.ConnectionParameters(
             host=host,
             port=port,
             virtual_host='/',
             credentials=pika.PlainCredentials(username, password),
-            blocked_connection_timeout=1,
+            connection_attempts=3,
         )
 
         # The pika connection to the broker
-        self._publish_connection: pika.adapters.BlockingConnection = None
-        self._consume_connection: pika.adapters.SelectConnection = None
-        self._consume_connection_ready_event = threading.Event()
-        self._consume_subscription_ready_event = threading.Event()
+        self._connection: pika.adapters.SelectConnection = None
+        self._channel_in: Channel = None
+        self._channel_out: Channel = None
+
+        self._thread: threading.Thread | None = None
 
         # Callback to the topics_to_handler list inside of
         self._topics_to_handlers = topics_to_handlers
         # mapping of topics to callables which can unsubscribe from the topic
-        self._topics_to_channel_cancel_callbacks: dict[str, Callable[[], None]] = {}
-        self._consumer_thread = None
+        self._topics_to_consumer_tags: dict[str, str] = {}
 
-    @retry(
-        stop_max_attempt_number=5,
-        wait_exponential_multiplier=1000,
-        wait_exponential_max=60000,
-    )
+        self._should_disconnect = False
+
     def connect(self) -> None:
         """Connect to the defined broker.
 
         Try to connect to the broker, performing exponential backoff if connection fails.
         """
-        # need deamon=True otherwise if tests fails it hangs trying to acquire lock
-        self.thread = threading.Thread(target=self._start_consuming, daemon=True)
-        self.thread.start()
-        self._publish_connection = pika.adapters.BlockingConnection(self._connection_params)
-        self._consume_connection_ready_event.wait(timeout=5)
+        self._should_disconnect = False
+
+        if not self._thread:
+            self._thread = threading.Thread(target=self._init_connection, daemon=True)
+            self._thread.start()
+
+        # maybe consider using threading events here
+        while self._channel_in is None and self._channel_out is None:
+            time.sleep(0.1)
 
     def disconnect(self) -> None:
-        """Close all connections.
+        """Close all connections."""
+        self._should_disconnect = True
+        for topic, tag in self._topics_to_consumer_tags.items():
+            self._cancel_consumer_tag(topic, tag)
 
-        Close both the public and consume connections and stop the consuming thread.
-        """
-        self._publish_connection.close()
-        self._publish_connection = None
-        self._consume_connection.ioloop.add_callback_threadsafe(self._close_consume_connection)
-        # as soon as connection is closed, the ioloop.stop will be
-        # called which in turn will terminate the consuming thread
-        self.thread.join(5)
-        self._consume_connection = None
+        # since _should_disconnect was set, _connection.ioloop.stop() will now execute after explicit connection close
+        self._connection.close()
+
+        if self._thread:
+            self._thread.join()
+            self._thread = None
 
     def is_connected(self) -> bool:
         """Check if there is an active connection to the broker.
@@ -109,11 +150,11 @@ class AMQPClient(BrokerClient):
             A boolean. True if there is a connection, False if not.
         """
         # We are connected to the broker if either the publish or consume connections is open
-        return (self._publish_connection is not None and self._publish_connection.is_open) or (
-            self._consume_connection is not None and self._consume_connection.is_open
+        return self._connection is not None and (
+            not self._connection.is_closed or not self._connection.is_closing
         )
 
-    def publish(self, topic: str, payload: bytes) -> None:
+    def publish(self, topic: str, payload: bytes, persist: bool) -> None:
         """Publish the given message.
 
         Publish payload with the pre-existing connection (via connect()) on topic.
@@ -121,135 +162,229 @@ class AMQPClient(BrokerClient):
         Args:
             topic: The topic on which to publish the message as a string
             payload: The message to publish, as raw bytes.
+            persist: True if message should persist until consumers available, False if message should be removed immediately.
         """
-        channel = self._publish_connection.channel()
-        channel.exchange_declare(topic, exchange_type='fanout', durable=True)
-        # this will send the message to topic exchange and distribute to all
-        # queues that subscribed to it
-        channel.basic_publish(
-            exchange=topic,
+        topic = _hierarchy_2_amqp(topic)
+        self._channel_out.basic_publish(
+            exchange=_INTERSECT_MESSAGE_EXCHANGE,
             routing_key=topic,
             body=payload,
-            properties=pika.BasicProperties(content_type='text/plain'),
+            properties=pika.BasicProperties(
+                content_type='text/plain',
+                delivery_mode=pika.delivery_mode.DeliveryMode.Persistent
+                if persist
+                else pika.delivery_mode.DeliveryMode.Transient,
+                # expiration=None if persist else 0,
+            ),
         )
-        channel.close()
 
-    def subscribe(self, topic: str) -> None:
-        self._consume_subscription_ready_event.clear()
-        self._subscribe_to_queue(topic)
-        self._consume_subscription_ready_event.wait()
+    def subscribe(self, topic: str, persist: bool) -> None:
+        """Subscribe to a topic.
+
+        topic: system-of-system hierarchy. In AMQP parlance this gets translated to the routing key.
+        persist: If True, we will create an idempotent queue name which should persist
+          even on broker or application shutdown. If False, we will allow the server to create a unique
+          queue name, and the queue will be destroyed once the associated channel is closed.
+
+        """
+        topic = _hierarchy_2_amqp(topic)
+        cb = functools.partial(
+            self._create_queue, channel=self._channel_in, topic=topic, persist=persist
+        )
+        self._connection.ioloop.add_callback_threadsafe(cb)
 
     def unsubscribe(self, topic: str) -> None:
-        old_channel = self._topics_to_channel_cancel_callbacks.get(topic, None)
-        if old_channel:
-            old_channel()
-            del self._topics_to_channel_cancel_callbacks[topic]
+        """Stop consuming from a topic.
 
-    def _start_consuming(self) -> None:
-        """Start consuming messages from broker.
-
-        Open the consuming connection and start its io loop.
+        With INTERSECT's AMQP configuration, each queue will only have one consumer.
+        Therefore, transient queues will be cleaned up.
         """
-        self._consume_connection = pika.adapters.SelectConnection(
-            parameters=self._connection_params,
-            on_close_callback=(
-                lambda _connection, _exception: self._consume_connection.ioloop.stop()
-            ),
-            on_open_callback=lambda _connection: self._consume_connection_ready_event.set(),
+        amqp_topic = _hierarchy_2_amqp(topic)
+        consumer_tag = self._topics_to_consumer_tags.get(amqp_topic, None)
+        if consumer_tag:
+            self._cancel_consumer_tag(amqp_topic, consumer_tag)
+
+    def _cancel_consumer_tag(self, topic: str, consumer_tag: str) -> None:
+        if self._channel_in and self._channel_in.is_open:
+            cb = functools.partial(self._cancel_consumer_tag_cb, topic=topic)
+            self._channel_in.basic_cancel(
+                consumer_tag,
+                callback=cb,
+            )
+
+    def _cancel_consumer_tag_cb(self, _frame: pika.frame.Frame, topic: str) -> None:
+        try:
+            del self._topics_to_consumer_tags[topic]
+        except KeyError:
+            # shouldn't happen because ControlPlaneManager gatekeeps consecutive remove_subscription_channel() calls
+            pass
+        logger.info('Unsubscribed from %s', topic)
+
+    # BEGIN CALLBACKS + THREADSAFE FUNCTIONS #
+
+    def _init_connection(self) -> None:
+        """Open the consuming connection and start its io loop.
+
+        NOTE: ANY functions which are not eventually called from this function
+        should be called via self._connection.ioloop.add_callback_threadsafe(cb)
+        """
+        while not self._should_disconnect:
+            self._connection = pika.adapters.SelectConnection(
+                parameters=self._connection_params,
+                on_close_callback=self._on_connection_closed,
+                on_open_error_callback=self._on_connection_open_error,
+                on_open_callback=self._on_connection_open,
+            )
+
+            # Loops forever until ioloop.stop is called WHEN self._should_disconnect is True
+            self._connection.ioloop.start()
+
+    def _on_connection_closed(self, connection: pika.SelectConnection, reason: Exception) -> None:
+        """This method is called if the connection to RabbitMQ closes."""
+        if self._should_disconnect:
+            connection.ioloop.stop()
+        else:
+            logger.warn('Connection closed, reopening in 5 seconds: %s', reason)
+            connection.ioloop.call_later(5, connection.ioloop.stop)
+        self._channel_out = None
+        self._channel_in = None
+
+    def _on_connection_open_error(self, connection: pika.SelectConnection, err: Exception) -> None:
+        """This gets called if the connection to RabbitMQ can't be established.
+
+        We may want to fail on retry here.
+        """
+        logger.error('Connection open failed, reopening in 5 seconds: %s', err)
+        connection.ioloop.call_later(5, connection.ioloop.stop)
+
+    def _on_connection_open(self, connection: pika.SelectConnection) -> None:
+        logger.info('AMQP connection open')
+        self._topics_to_consumer_tags.clear()
+        connection.channel(on_open_callback=self._on_input_channel_open)
+        connection.channel(on_open_callback=self._on_output_channel_open)
+
+    def _on_channel_closed(
+        self, channel: Channel, exception: pika.exceptions.ChannelClosed
+    ) -> None:
+        if self._connection.is_open:
+            # This should rarely happen in practice, should only happen if you attempt to do something which violates the protocol.
+            logger.error(
+                'Closing connection due to closed channel %s, please check the usage of the SDK or your configuration. Exception: %s',
+                channel,
+                str(exception),
+            )
+            self._connection.close(reply_code=exception.reply_code, reply_text=exception.reply_text)
+
+    # PRODUCER #
+    def _on_output_channel_open(self, channel: Channel) -> None:
+        self._channel_out = channel
+        self._channel_out.add_on_close_callback(self._on_channel_closed)
+        logger.info('AMQP: output channel ready')
+
+    # CONSUMER #
+    def _on_input_channel_open(self, channel: Channel) -> None:
+        self._channel_in = channel
+        self._channel_in.add_on_close_callback(self._on_channel_closed)
+        cb = functools.partial(self._on_exchange_declareok, channel=channel)
+        channel.exchange_declare(
+            exchange=_INTERSECT_MESSAGE_EXCHANGE, exchange_type='topic', durable=True, callback=cb
         )
 
-        self._consume_connection.ioloop.start()
+    def _on_exchange_declareok(self, _unused_frame: Frame, channel: Channel) -> None:
+        """Create a queue on the broker (called from AMQP).
 
-    def _subscribe_to_queue(self, topic: str) -> None:
-        """Start consuming from the given topic.
-
-        Declares the correct exchange and queue on the broker if needed, then starts
-        consuming messages on that queue.
+        After verifying that the exchange exists, we can now proceed to execute
+        "initial subscriptions".
 
         Args:
-            topic: Name of the topic on the broker to subscribe to as a string.
-        """
-        # in consumer thread: open channel-> declare queue (need that if we starte
-        # consuming  before message is published (no queue yet)) -> start consuming
-        cb = functools.partial(self._open_channel, topic=topic)
-        self._consume_connection.ioloop.add_callback_threadsafe(cb)
-
-    def _open_channel(self, topic: str) -> None:
-        """Open a channel for the given topic.
-
-        Args:
-            topic: The topic to open a channel for as a string.
-        """
-        cb = functools.partial(self._on_channel_open, topic=topic)
-        self._consume_connection.channel(on_open_callback=cb)
-
-    def _on_channel_open(self, channel: Channel, topic: str) -> None:
-        """Create an exchange on the broker.
-
-        Used as a listener on channel open.
-
-        Args:
+            _unused_frame: response from declaring the exchange on the broker (irrelevant).
             channel: The Channel being instantiated.
-            topic: The string name for the Channel on the broker.
         """
-        cb = functools.partial(self._on_exchange_declareok, channel=channel, topic=topic)
-        channel.exchange_declare(exchange=topic, exchange_type='fanout', durable=True, callback=cb)
+        for topic, topic_handler in self._topics_to_handlers().items():
+            amqp_topic = _hierarchy_2_amqp(topic)
+            cb = functools.partial(
+                self._create_queue,
+                channel=channel,
+                topic=amqp_topic,
+                persist=topic_handler.topic_persist,
+            )
+            self._connection.ioloop.add_callback_threadsafe(cb)
 
-    def _on_exchange_declareok(self, _unused_frame: Frame, channel: Channel, topic: str) -> None:
+    def _create_queue(self, channel: Channel, topic: str, persist: bool) -> None:
         """Create a queue on the broker.
 
-        Used as a listener on exchange declaration.
+        This can be called directly from the AMQP Client if the subscribed connection already has a Channel it's listening to.
 
         Args:
-            _unused_frame: Object from pika. Ignored.
             channel: The Channel being instantiated.
             topic: The string name for the Channel on the broker.
+            persist: boolean value to determine how we manage the queue.
+              If True, this queue will persist forever, even on application or broker shutdown, and we need a persistent name.
+              If False, we will generate a temporary queue using the broker's naming scheme.
         """
         cb = functools.partial(self._on_queue_declareok, channel=channel, topic=topic)
-        channel.queue_declare(queue=topic + '.' + self.uid, durable=True, callback=cb)
+        channel.queue_declare(
+            queue=_get_queue_name(topic)
+            if persist
+            else '',  # if we're transient, let the broker generate a name for us
+            durable=persist,
+            exclusive=not persist,  # transient queues can be exclusive
+            callback=cb,
+        )
 
-    def _on_queue_declareok(self, _unused_frame: Frame, channel: Channel, topic: str) -> None:
+    def _on_queue_declareok(self, frame: Frame, channel: Channel, topic: str) -> None:
         """Begins listening on the given queue.
 
         Used as a listener on queue declaration.
 
         Args:
-            _unused_frame: Object from pika. Ignored.
+            frame: Response from the queue declare we sent to the AMQP broker. We get the queue name from this.
             channel: The Channel being instantiated.
             topic: The string name for the Channel on the broker.
         """
-        cb = functools.partial(self._on_queue_bindok, channel=channel, topic=topic)
-        channel.queue_bind(topic + '.' + self.uid, topic, routing_key=topic, callback=cb)
+        queue_name = frame.method.queue
+        cb = functools.partial(
+            self._on_queue_bindok, channel=channel, topic=topic, queue_name=queue_name
+        )
+        channel.queue_bind(
+            queue=queue_name,
+            exchange=_INTERSECT_MESSAGE_EXCHANGE,
+            routing_key=topic,
+            callback=cb,
+        )
 
-    def _on_queue_bindok(self, _unused_frame: Frame, channel: Channel, topic: str) -> None:
+    def _on_queue_bindok(
+        self, _unused_frame: Frame, channel: Channel, topic: str, queue_name: str
+    ) -> None:
         """Consumes a message from the given channel.
 
         Used as a listener on queue binding.
 
         Args:
-            _unused_frame: Object from pika. Ignored.
+            _unused_frame: AMQP response from binding to the queue. Ignored.
             channel: The Channel being instantiated.
-            topic: The string name for the Channel on the broker.
+            topic: Name of the topic on the broker.
+            queue_name: The name of the queue on the AMQP broker.
         """
-        cb = functools.partial(self._on_consume_ok)
+        cb = functools.partial(self._on_consume_ok, topic=topic)
         consumer_tag = channel.basic_consume(
-            queue=topic + '.' + self.uid,
+            queue=queue_name,
             auto_ack=True,
             on_message_callback=self._consume_message,
             callback=cb,
         )
-        self._topics_to_channel_cancel_callbacks[topic] = lambda: channel.basic_cancel(consumer_tag)
+        self._topics_to_consumer_tags[topic] = consumer_tag
 
-    def _on_consume_ok(self, _unused_frame: Frame) -> None:
-        """Sets the consume subscription ready even.
+    def _on_consume_ok(self, _unused_frame: Frame, topic: str) -> None:
+        """Sets the consume subscription ready event.
 
         Used as a listener on consuming an initial message on a channel.
 
         Args:
-            _unused_frame: Object from pika. Ignored.
-            topic: The string name for the Channel on the broker.
+            _unused_frame: AMQP response from successfully beginning consumption. Ignored.
+            topic: Name of the topic on the broker.
         """
-        self._consume_subscription_ready_event.set()
+        logger.info('ready to start consuming to %s', topic)
 
     def _consume_message(
         self,
@@ -263,18 +398,13 @@ class AMQPClient(BrokerClient):
         Looks up all handlers for the topic and delegates message handling to them.
 
         Args:
-            _unused_channel: The Pika channel the message was received on. Ignored
-            basic_deliver: Contains internal Pika delivery information - i.e. the routing key.
-            _properties: Object from the Pika call. Ignored.
-            body: the pika message to be handled.
+            _unused_channel: The AMQP channel the message was received on. Ignored
+            basic_deliver: Contains internal AMQP delivery information - i.e. the routing key.
+            _properties: Object from the AMQP call. Ignored.
+            body: the AMQP message to be handled.
         """
-        for handler in self._topics_to_handlers().get(basic_deliver.routing_key, []):
-            handler(body)
-
-    def _close_consume_connection(self) -> None:
-        """Closes the consume connection.
-
-        Used as a listener on the connection loop to safely shutdown.
-        """
-        self._consume_connection.close()
-        self._topics_to_channel_cancel_callbacks.clear()
+        tth_key = _amqp_2_hierarchy(basic_deliver.routing_key)
+        topic_handler = self._topics_to_handlers().get(tth_key)
+        if topic_handler:
+            for cb in topic_handler.callbacks:
+                cb(body)

--- a/src/intersect_sdk/_internal/control_plane/brokers/broker_client.py
+++ b/src/intersect_sdk/_internal/control_plane/brokers/broker_client.py
@@ -1,24 +1,21 @@
-from abc import ABC, abstractmethod
+from typing import Protocol
 
 
-class BrokerClient(ABC):
+class BrokerClient(Protocol):
     """Abstract definition of a Broker Client.
 
     Will abstractly manage interaction between implementation specific message broker
     calls and higher level pub/sub features.
     """
 
-    @abstractmethod
     def connect(self) -> None:
         """Connect to the defined broker. Credentials should be cached in the constructor."""
         ...
 
-    @abstractmethod
     def disconnect(self) -> None:
         """Disconnect from the defined broker."""
         ...
 
-    @abstractmethod
     def is_connected(self) -> bool:
         """Checks if there is an active connection to the broker.
 
@@ -27,7 +24,14 @@ class BrokerClient(ABC):
         """
         ...
 
-    @abstractmethod
+    def considered_unrecoverable(self) -> bool:
+        """Checks if the broker is considered to be in a state where it would be impossible to reconnect.
+
+        Returns:
+            A boolean. True if can't recover, False otherwise.
+        """
+        ...
+
     def publish(self, topic: str, payload: bytes, persist: bool) -> None:
         """Publishes the given message.
 
@@ -42,7 +46,6 @@ class BrokerClient(ABC):
         """
         ...
 
-    @abstractmethod
     def subscribe(self, topic: str, persist: bool) -> None:
         """Subscribe to a topic over the pre-existing connection (via connect()).
 
@@ -55,7 +58,6 @@ class BrokerClient(ABC):
         """
         ...
 
-    @abstractmethod
     def unsubscribe(self, topic: str) -> None:
         """Unsubscribe from a topic over the pre-existing connection (via connect()).
 

--- a/src/intersect_sdk/_internal/control_plane/control_plane_manager.py
+++ b/src/intersect_sdk/_internal/control_plane/control_plane_manager.py
@@ -167,3 +167,14 @@ class ControlPlaneManager:
         return self._ready and all(
             control_provider.is_connected() for control_provider in self._control_providers
         )
+
+    def considered_unrecoverable(self) -> bool:
+        """Check if any broker is considered to be in an unrecoverable state.
+
+        Returns:
+          - True if we can't recover, false otherwise
+        """
+        return any(
+            control_provider.considered_unrecoverable()
+            for control_provider in self._control_providers
+        )

--- a/src/intersect_sdk/_internal/control_plane/topic_handler.py
+++ b/src/intersect_sdk/_internal/control_plane/topic_handler.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Callable
+
+
+class TopicHandler:
+    """ControlPlaneManager information about a topic, avoids protocol specific information."""
+
+    callbacks: set[Callable[[bytes], None]]
+    """Set of functions to call when consuming a message.
+
+    (In practice there will only be one callback, but it could be helpful to add a debugging function callback in for development.)
+    """
+    topic_persist: bool
+    """Whether or not a topic queue is expected to persist on the message broker."""
+
+    def __init__(self, topic_persist: bool) -> None:
+        self.callbacks = set()
+        self.topic_persist = topic_persist

--- a/src/intersect_sdk/_internal/multi_flag_thread_event.py
+++ b/src/intersect_sdk/_internal/multi_flag_thread_event.py
@@ -1,0 +1,77 @@
+import threading
+
+
+class MultiFlagThreadEvent:
+    """Only set a single threading event if all flags are set.
+
+    NOTE: This is an internal API and does not do validation or control flow
+    with arguments to its methods.
+    """
+
+    def __init__(self, num_flags: int) -> None:
+        """Constructor.
+
+        Params:
+          num_flags: This should be a positive value.
+            You may suffer performance issues if this is >= 63
+        """
+        self._flag = threading.Event()
+        self._bitmask = 0b0
+        """Value which gets modified. If it equals bitmask_target, set the flag; otherwise, don't."""
+        self._bitmask_target = (1 << num_flags) - 1
+        """Immutable number where all bits are set to 1"""
+
+    def unset_all(self) -> None:
+        """Clear all flags."""
+        self._flag.clear()
+        self._bitmask = 0b0
+
+    def set_all(self) -> None:
+        """Set all flags."""
+        self._flag.set()
+        self._bitmask = self._bitmask_target
+
+    def set_nth_flag(self, flag: int) -> None:
+        """Set a flag.
+
+        If all other flags are set, this sets the threading event.
+
+        Params:
+          flag: position of flag you want to set (0-indexed), should be less than the value provided in the constructor
+        """
+        self._bitmask |= 1 << flag
+        if self._bitmask == self._bitmask_target:
+            self._flag.set()
+
+    def unset_nth_flag(self, flag: int) -> None:
+        """Unset a flag and the threading event.
+
+        Params:
+          flag: position of flag you want to set (0-indexed), should be less than the value provided in the constructor
+        """
+        self._bitmask &= ~(1 << flag)
+        self._flag.clear()
+
+    def is_nth_flag_set(self, flag: int) -> bool:
+        """Check to see if a specific flag is set.
+
+        Params:
+          flag: position of flag you want to check (0-indexed), should be less than the value provided in the constructor
+        """
+        return (self._bitmask >> flag) & 1 == 1
+
+    def wait(self, amount: float) -> None:
+        """Block until internal flag is True, which will only happen once all other flags are set.
+
+        Params:
+          amount: time to block
+        """
+        self._flag.wait(amount)
+
+    def is_set(self) -> bool:
+        """Determine if flag was set. Useful as the "while" condition for application loops.
+
+        Returns:
+          True if set, False otherwise
+        """
+        return self._flag.is_set()

--- a/src/intersect_sdk/config/client.py
+++ b/src/intersect_sdk/config/client.py
@@ -48,5 +48,20 @@ class IntersectClientConfig(BaseModel):
     (default: False)
     """
 
+    system: Annotated[str, Field('tmp-')]
+    """
+    Name of the "system", could also be thought of as a "device" (should be unique within a facility)
+    """
+
+    facility: Annotated[str, Field('tmp-')]
+    """
+    Name of the facility (an ORNL institutional designation, i.e. 'neutrons') (NOT abbreviated, should be unique within an organization)
+    """
+
+    organization: Annotated[str, Field('tmp-')]
+    """
+    Name of the organization (i.e. 'ornl') (NOT abbreviated) (should be unique in an INTERSECT cluster)
+    """
+
     # pydantic config
     model_config = ConfigDict(revalidate_instances='always')

--- a/src/intersect_sdk/service.py
+++ b/src/intersect_sdk/service.py
@@ -249,7 +249,13 @@ class IntersectService(IntersectEventObserver):
             self._status_thread.join()
             self._status_thread = None
 
-        self._send_lifecycle_message(lifecycle_type=LifecycleType.SHUTDOWN, payload=reason)
+        try:
+            self._send_lifecycle_message(lifecycle_type=LifecycleType.SHUTDOWN, payload=reason)
+        except Exception as e:  # noqa: BLE001  (this could fail on numerous protocols)
+            logger.error(
+                'Could not send shutdown message, INTERSECT Core will eventually assume this Service has shutdown.'
+            )
+            logger.debug(e)
 
         self._control_plane_manager.disconnect()
 

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -128,3 +128,7 @@ def test_example_2_count_examples():
 
 def test_example_3_ping_pong_events():
     assert run_example_test('3_ping_pong_events') == 'ping\npong\nping\npong\n'
+
+
+def test_example_3_ping_pong_events_amqp():
+    assert run_example_test('3_ping_pong_events_amqp') == 'ping\npong\nping\npong\n'

--- a/tests/integration/test_return_type_mismatch.py
+++ b/tests/integration/test_return_type_mismatch.py
@@ -79,7 +79,7 @@ def make_message_interceptor() -> ControlPlaneManager:
                 port=1883,
                 protocol='mqtt3.1.1',
             )
-        ]
+        ],
     )
 
 
@@ -96,7 +96,7 @@ def test_call_user_function_with_invalid_payload():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -112,6 +112,7 @@ def test_call_user_function_with_invalid_payload():
             # calculate_fibonacci takes in a tuple of two integers but we'll just send it one
             payload=b'2',
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown()

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -73,7 +73,7 @@ def make_message_interceptor() -> ControlPlaneManager:
                 port=1883,
                 protocol='mqtt3.1.1',
             )
-        ]
+        ],
     )
 
 
@@ -112,7 +112,7 @@ def test_call_user_function():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -127,6 +127,7 @@ def test_call_user_function():
             operation_id='calculate_fibonacci',
             payload=b'[4,6]',
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown()
@@ -146,7 +147,7 @@ def test_call_static_user_function():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -161,6 +162,7 @@ def test_call_static_user_function():
             operation_id='test_generator',
             payload=b'"res"',
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown()
@@ -179,7 +181,7 @@ def test_call_user_function_with_default_and_empty_payload():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -194,6 +196,7 @@ def test_call_user_function_with_default_and_empty_payload():
             operation_id='valid_default_argument',
             payload=b'null',  # if sending null as the payload, the SDK will call the function's default value
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown()
@@ -213,7 +216,7 @@ def test_call_user_function_with_invalid_payload():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -229,6 +232,7 @@ def test_call_user_function_with_invalid_payload():
             # calculate_fibonacci takes in a tuple of two integers but we'll just send it one
             payload=b'[2]',
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown()
@@ -251,7 +255,7 @@ def test_call_nonexistent_user_function():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -267,6 +271,7 @@ def test_call_nonexistent_user_function():
             # calculate_fibonacci takes in a tuple of two integers but we'll just send it one
             payload=b'null',
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown()
@@ -287,7 +292,7 @@ def test_call_minio_user_function():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}
+        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
@@ -302,6 +307,7 @@ def test_call_minio_user_function():
             operation_id='test_datetime',
             payload=b'"1970-01-01T00:00:00Z"',
         ),
+        True,
     )
     time.sleep(5.0)
     intersect_service.shutdown()
@@ -330,10 +336,10 @@ def test_lifecycle_messages():
         messages.append(deserialize_and_validate_lifecycle_message(payload))
 
     message_interceptor.add_subscription_channel(
-        'test/test/test/test/test/lifecycle', {lifecycle_msg_callback}
+        'test/test/test/test/test/lifecycle', {lifecycle_msg_callback}, False
     )
     # we do not really care about the userspace message response, but we'll listen to it to consume it
-    message_interceptor.add_subscription_channel('msg/msg/msg/msg/msg/userspace', set())
+    message_interceptor.add_subscription_channel('msg/msg/msg/msg/msg/userspace', set(), False)
     message_interceptor.connect()
     # sleep a moment to make sure message_interceptor catches the startup message
     time.sleep(1.0)
@@ -353,6 +359,7 @@ def test_lifecycle_messages():
             # note that the dict key MUST be a string, even though the input wants a float key
             payload=b'{"1.2":"one point two"}',
         ),
+        True,
     )
     time.sleep(3.0)
     intersect_service.shutdown('I want to shutdown')

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -96,7 +96,7 @@ def test_control_plane_connections():
     assert len(channels) == 1
     # ... and one callback function for this channel
     channel_key = next(iter(channels))
-    assert len(channels[channel_key]) == 1
+    assert len(channels[channel_key].callbacks) == 1
 
     intersect_service._control_plane_manager.remove_subscription_channel(channel_key)
     assert len(intersect_service._control_plane_manager.get_subscription_channels()) == 0


### PR DESCRIPTION
Will probably add this to a v0.6.3 release since the public API does not change at all, but note that internally AMQP functions very differently.

## Possible changes needed for experiment controller

Whenever calling some of the ControlPlaneManager functions (add_subscription_channel and publish_message), you'll now need to add a `persist` boolean flag onto the calls - certain messages persist and certain messages don't.

## AMQP CHANGES

- unsubscribe actually works now (added another AMQP E2E test to prove it)
- Now use topic exchanges instead of fanout exchanges. Instead of creating an exchange for each topic like we were doing (and queues for each), we use a single hardcoded exchange. Some queues are meant to be dedicated (for example: Services will handle Userspace messages in their own dedicated queue, and INTERSECT Core Services will always use a dedicated queue for all messages), while other queues are meant to be transient (for example: when listening to events, Clients will create a temporary transient queue).

What I'd like to do in the future would be to create the exchanges, the dedicated queues, and the queue/exchange bindings on RabbitMQ (the server) instead of in the SDK (both Services and Clients act as RabbitMQ clients). This will allow us to configure AUTH on the broker itself by topic, and not "rely" on something using the SDK inappropriately reading/writing messages from certain dedicated queues.

## General Changes

Both the MQTT and the AMQP implementations are now more robust regarding reconnecting to the broker. Both will attempt to reconnect on failure, and both will automatically resubscribe to all topics they should be subscribed to once the reconnect is successful.