### PR TITLE
Multi-capability and svc2svc support for services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.11.2
+    rev: 2.17.2
     hooks:
       - id: pdm-export
         args: ['--without-hashes']

--- a/docs/api/callback_definitions.rst
+++ b/docs/api/callback_definitions.rst
@@ -1,0 +1,27 @@
+====================
+Callback Definitions
+====================
+
+Shared
+======
+
+.. automodule:: intersect_sdk.shared_callback_definitions
+   :members:
+   :undoc-members:
+   :exclude-members: model_computed_fields, model_config, model_fields
+
+Client
+======
+
+.. automodule:: intersect_sdk.client_callback_definitions
+   :members:
+   :undoc-members:
+   :exclude-members: model_computed_fields, model_config, model_fields
+
+Service
+=======
+
+.. automodule:: intersect_sdk.service_callback_definitions
+   :members:
+   :undoc-members:
+   :exclude-members: model_computed_fields, model_config, model_fields

--- a/docs/api/client_callback_definitions.rst
+++ b/docs/api/client_callback_definitions.rst
@@ -1,7 +1,0 @@
-Client Callback Definitions
-===========================
-
-.. automodule:: intersect_sdk.client_callback_definitions
-   :members:
-   :undoc-members:
-   :exclude-members: model_computed_fields, model_config, model_fields

--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -1,0 +1,27 @@
+======
+Config
+======
+
+Config - Shared
+===============
+
+.. automodule:: intersect_sdk.config.shared
+   :members:
+   :undoc-members:
+   :exclude-members: model_computed_fields, model_config, model_fields
+
+Config - Service
+================
+
+.. automodule:: intersect_sdk.config.service
+   :members:
+   :undoc-members:
+   :exclude-members: model_computed_fields, model_config, model_fields
+
+Config - Client
+===============
+
+.. automodule:: intersect_sdk.config.client
+   :members:
+   :undoc-members:
+   :exclude-members: model_computed_fields, model_config, model_fields

--- a/docs/api/config_client.rst
+++ b/docs/api/config_client.rst
@@ -1,7 +1,0 @@
-Config - Client
-===============
-
-.. automodule:: intersect_sdk.config.client
-   :members:
-   :undoc-members:
-   :exclude-members: model_computed_fields, model_config, model_fields

--- a/docs/api/config_service.rst
+++ b/docs/api/config_service.rst
@@ -1,7 +1,0 @@
-Config - Service
-================
-
-.. automodule:: intersect_sdk.config.service
-   :members:
-   :undoc-members:
-   :exclude-members: model_computed_fields, model_config, model_fields

--- a/docs/api/config_shared.rst
+++ b/docs/api/config_shared.rst
@@ -1,7 +1,0 @@
-Config - Shared
-===============
-
-.. automodule:: intersect_sdk.config.shared
-   :members:
-   :undoc-members:
-   :exclude-members: model_computed_fields, model_config, model_fields

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,16 +31,14 @@ This site provides documentation for INTERSECT's Python SDK. See the getting sta
    :maxdepth: 2
    :caption: API documentation
 
-   api/config_service
-   api/config_client
-   api/config_shared
+   api/config
    api/core_definitions
    api/schema
    api/capability
-   api/service_definitions
    api/service
-   api/client_callback_definitions
+   api/service_definitions
    api/client
+   api/callback_definitions
    api/app_lifecycle
    api/constants
    api/version

--- a/examples/1_hello_world/hello_client.py
+++ b/examples/1_hello_world/hello_client.py
@@ -2,10 +2,10 @@ import logging
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
-    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
+    IntersectDirectMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -74,7 +74,7 @@ if __name__ == '__main__':
       you'll get a message back.
     """
     initial_messages = [
-        DirectMessageParams(
+        IntersectDirectMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
             operation='HelloExample.say_hello_to_name',
             payload='hello_client',

--- a/examples/1_hello_world/hello_client.py
+++ b/examples/1_hello_world/hello_client.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     initial_messages = [
         IntersectClientMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
-            operation='say_hello_to_name',
+            operation='HelloExample.say_hello_to_name',
             payload='hello_client',
         )
     ]

--- a/examples/1_hello_world/hello_client.py
+++ b/examples/1_hello_world/hello_client.py
@@ -2,10 +2,10 @@ import logging
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
+    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
-    IntersectClientMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -74,7 +74,7 @@ if __name__ == '__main__':
       you'll get a message back.
     """
     initial_messages = [
-        IntersectClientMessageParams(
+        DirectMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
             operation='HelloExample.say_hello_to_name',
             payload='hello_client',

--- a/examples/1_hello_world/hello_service.py
+++ b/examples/1_hello_world/hello_service.py
@@ -79,11 +79,12 @@ if __name__ == '__main__':
     @intersect_message and @intersect_status, and that these functions are appropriately type-annotated.
     """
     capability = HelloServiceCapabilityImplementation()
+    capability.capability_name = "HelloExample"
 
     """
     step three - create service from both the configuration and your own capability
     """
-    service = IntersectService(capability, config)
+    service = IntersectService([capability], config)
 
     """
     step four - start lifecycle loop. The only necessary parameter is your service.

--- a/examples/1_hello_world/hello_service.py
+++ b/examples/1_hello_world/hello_service.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     @intersect_message and @intersect_status, and that these functions are appropriately type-annotated.
     """
     capability = HelloServiceCapabilityImplementation()
-    capability.capability_name = "HelloExample"
+    capability.capability_name = 'HelloExample'
 
     """
     step three - create service from both the configuration and your own capability

--- a/examples/1_hello_world_amqp/hello_client.py
+++ b/examples/1_hello_world_amqp/hello_client.py
@@ -2,10 +2,10 @@ import logging
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
+    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
-    IntersectClientMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -76,7 +76,7 @@ if __name__ == '__main__':
       you'll get a message back.
     """
     initial_messages = [
-        IntersectClientMessageParams(
+        DirectMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
             operation='HelloExample.say_hello_to_name',
             payload='hello_client',

--- a/examples/1_hello_world_amqp/hello_client.py
+++ b/examples/1_hello_world_amqp/hello_client.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     initial_messages = [
         IntersectClientMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
-            operation='say_hello_to_name',
+            operation='HelloExample.say_hello_to_name',
             payload='hello_client',
         )
     ]

--- a/examples/1_hello_world_amqp/hello_client.py
+++ b/examples/1_hello_world_amqp/hello_client.py
@@ -2,10 +2,10 @@ import logging
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
-    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
+    IntersectDirectMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -76,7 +76,7 @@ if __name__ == '__main__':
       you'll get a message back.
     """
     initial_messages = [
-        DirectMessageParams(
+        IntersectDirectMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
             operation='HelloExample.say_hello_to_name',
             payload='hello_client',

--- a/examples/1_hello_world_amqp/hello_service.py
+++ b/examples/1_hello_world_amqp/hello_service.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     @intersect_message and @intersect_status, and that these functions are appropriately type-annotated.
     """
     capability = HelloServiceCapabilityImplementation()
-    capability.capability_name = "HelloExample"
+    capability.capability_name = 'HelloExample'
 
     """
     step three - create service from both the configuration and your own capability

--- a/examples/1_hello_world_amqp/hello_service.py
+++ b/examples/1_hello_world_amqp/hello_service.py
@@ -80,11 +80,12 @@ if __name__ == '__main__':
     @intersect_message and @intersect_status, and that these functions are appropriately type-annotated.
     """
     capability = HelloServiceCapabilityImplementation()
+    capability.capability_name = "HelloExample"
 
     """
     step three - create service from both the configuration and your own capability
     """
-    service = IntersectService(capability, config)
+    service = IntersectService([capability], config)
 
     """
     step four - start lifecycle loop. The only necessary parameter is your service.

--- a/examples/1_hello_world_events/hello_client.py
+++ b/examples/1_hello_world_events/hello_client.py
@@ -2,10 +2,10 @@ import logging
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
-    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
+    IntersectDirectMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -95,7 +95,7 @@ if __name__ == '__main__':
       you'll get a message back.
     """
     initial_messages = [
-        DirectMessageParams(
+        IntersectDirectMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
             operation='HelloExample.say_hello_to_name',
             payload='hello_client',

--- a/examples/1_hello_world_events/hello_client.py
+++ b/examples/1_hello_world_events/hello_client.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
     initial_messages = [
         IntersectClientMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
-            operation='say_hello_to_name',
+            operation='HelloExample.say_hello_to_name',
             payload='hello_client',
         )
     ]

--- a/examples/1_hello_world_events/hello_client.py
+++ b/examples/1_hello_world_events/hello_client.py
@@ -2,10 +2,10 @@ import logging
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
+    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
-    IntersectClientMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -95,7 +95,7 @@ if __name__ == '__main__':
       you'll get a message back.
     """
     initial_messages = [
-        IntersectClientMessageParams(
+        DirectMessageParams(
             destination='hello-organization.hello-facility.hello-system.hello-subsystem.hello-service',
             operation='HelloExample.say_hello_to_name',
             payload='hello_client',

--- a/examples/1_hello_world_events/hello_service.py
+++ b/examples/1_hello_world_events/hello_service.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     @intersect_message and @intersect_status, and that these functions are appropriately type-annotated.
     """
     capability = HelloServiceCapabilityImplementation()
-    capability.capability_name = "HelloExample"
+    capability.capability_name = 'HelloExample'
 
     """
     step three - create service from both the configuration and your own capability

--- a/examples/1_hello_world_events/hello_service.py
+++ b/examples/1_hello_world_events/hello_service.py
@@ -83,11 +83,12 @@ if __name__ == '__main__':
     @intersect_message and @intersect_status, and that these functions are appropriately type-annotated.
     """
     capability = HelloServiceCapabilityImplementation()
+    capability.capability_name = "HelloExample"
 
     """
     step three - create service from both the configuration and your own capability
     """
-    service = IntersectService(capability, config)
+    service = IntersectService([capability], config)
 
     """
     step four - start lifecycle loop. The only necessary parameter is your service.

--- a/examples/2_counting/counting_client.py
+++ b/examples/2_counting/counting_client.py
@@ -4,10 +4,10 @@ import time
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
-    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
+    IntersectDirectMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -38,7 +38,7 @@ class SampleOrchestrator:
         self.message_stack = [
             # wait 5 seconds before stopping the counter. "Count" in response will be approx. 6
             (
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.stop_count',
                     payload=None,
@@ -47,7 +47,7 @@ class SampleOrchestrator:
             ),
             # start the counter up again - it will not be 0 at this point! "Count" in response will be approx. 7
             (
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.start_count',
                     payload=None,
@@ -56,7 +56,7 @@ class SampleOrchestrator:
             ),
             # reset the counter, but have it immediately start running again. "Count" in response will be approx. 10
             (
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.reset_count',
                     payload=True,
@@ -65,7 +65,7 @@ class SampleOrchestrator:
             ),
             # reset the counter, but don't have it run again. "Count" in response will be approx. 6
             (
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.reset_count',
                     payload=False,
@@ -74,7 +74,7 @@ class SampleOrchestrator:
             ),
             # start the counter back up. "Count" in response will be approx. 1
             (
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.start_count',
                     payload=None,
@@ -83,7 +83,7 @@ class SampleOrchestrator:
             ),
             # finally, stop the counter one last time. "Count" in response will be approx. 4
             (
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.stop_count',
                     payload=None,
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     # The counter will start after the initial message.
     # If the service is already active and counting, this may do nothing.
     initial_messages = [
-        DirectMessageParams(
+        IntersectDirectMessageParams(
             destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
             operation='CountingExample.start_count',
             payload=None,

--- a/examples/2_counting/counting_client.py
+++ b/examples/2_counting/counting_client.py
@@ -4,10 +4,10 @@ import time
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
+    DirectMessageParams,
     IntersectClient,
     IntersectClientCallback,
     IntersectClientConfig,
-    IntersectClientMessageParams,
     default_intersect_lifecycle_loop,
 )
 
@@ -38,7 +38,7 @@ class SampleOrchestrator:
         self.message_stack = [
             # wait 5 seconds before stopping the counter. "Count" in response will be approx. 6
             (
-                IntersectClientMessageParams(
+                DirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.stop_count',
                     payload=None,
@@ -47,7 +47,7 @@ class SampleOrchestrator:
             ),
             # start the counter up again - it will not be 0 at this point! "Count" in response will be approx. 7
             (
-                IntersectClientMessageParams(
+                DirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.start_count',
                     payload=None,
@@ -56,7 +56,7 @@ class SampleOrchestrator:
             ),
             # reset the counter, but have it immediately start running again. "Count" in response will be approx. 10
             (
-                IntersectClientMessageParams(
+                DirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.reset_count',
                     payload=True,
@@ -65,7 +65,7 @@ class SampleOrchestrator:
             ),
             # reset the counter, but don't have it run again. "Count" in response will be approx. 6
             (
-                IntersectClientMessageParams(
+                DirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.reset_count',
                     payload=False,
@@ -74,7 +74,7 @@ class SampleOrchestrator:
             ),
             # start the counter back up. "Count" in response will be approx. 1
             (
-                IntersectClientMessageParams(
+                DirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.start_count',
                     payload=None,
@@ -83,7 +83,7 @@ class SampleOrchestrator:
             ),
             # finally, stop the counter one last time. "Count" in response will be approx. 4
             (
-                IntersectClientMessageParams(
+                DirectMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
                     operation='CountingExample.stop_count',
                     payload=None,
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     # The counter will start after the initial message.
     # If the service is already active and counting, this may do nothing.
     initial_messages = [
-        IntersectClientMessageParams(
+        DirectMessageParams(
             destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
             operation='CountingExample.start_count',
             payload=None,

--- a/examples/2_counting/counting_client.py
+++ b/examples/2_counting/counting_client.py
@@ -40,7 +40,7 @@ class SampleOrchestrator:
             (
                 IntersectClientMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-                    operation='stop_count',
+                    operation='CountingExample.stop_count',
                     payload=None,
                 ),
                 5.0,
@@ -49,7 +49,7 @@ class SampleOrchestrator:
             (
                 IntersectClientMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-                    operation='start_count',
+                    operation='CountingExample.start_count',
                     payload=None,
                 ),
                 1.0,
@@ -58,7 +58,7 @@ class SampleOrchestrator:
             (
                 IntersectClientMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-                    operation='reset_count',
+                    operation='CountingExample.reset_count',
                     payload=True,
                 ),
                 3.0,
@@ -67,7 +67,7 @@ class SampleOrchestrator:
             (
                 IntersectClientMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-                    operation='reset_count',
+                    operation='CountingExample.reset_count',
                     payload=False,
                 ),
                 5.0,
@@ -76,7 +76,7 @@ class SampleOrchestrator:
             (
                 IntersectClientMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-                    operation='start_count',
+                    operation='CountingExample.start_count',
                     payload=None,
                 ),
                 3.0,
@@ -85,7 +85,7 @@ class SampleOrchestrator:
             (
                 IntersectClientMessageParams(
                     destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-                    operation='stop_count',
+                    operation='CountingExample.stop_count',
                     payload=None,
                 ),
                 3.0,
@@ -160,7 +160,7 @@ if __name__ == '__main__':
     initial_messages = [
         IntersectClientMessageParams(
             destination='counting-organization.counting-facility.counting-system.counting-subsystem.counting-service',
-            operation='start_count',
+            operation='CountingExample.start_count',
             payload=None,
         )
     ]

--- a/examples/2_counting/counting_service.py
+++ b/examples/2_counting/counting_service.py
@@ -191,7 +191,7 @@ if __name__ == '__main__':
         **from_config_file,
     )
     capability = CountingServiceCapabilityImplementation()
-    capability.capability_name = "CountingExample"
+    capability.capability_name = 'CountingExample'
     service = IntersectService([capability], config)
     logger.info('Starting counting_service, use Ctrl+C to exit.')
     default_intersect_lifecycle_loop(

--- a/examples/2_counting/counting_service.py
+++ b/examples/2_counting/counting_service.py
@@ -191,7 +191,8 @@ if __name__ == '__main__':
         **from_config_file,
     )
     capability = CountingServiceCapabilityImplementation()
-    service = IntersectService(capability, config)
+    capability.capability_name = "CountingExample"
+    service = IntersectService([capability], config)
     logger.info('Starting counting_service, use Ctrl+C to exit.')
     default_intersect_lifecycle_loop(
         service,

--- a/examples/2_counting_events/counting_service.py
+++ b/examples/2_counting_events/counting_service.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         **from_config_file,
     )
     capability = CountingServiceCapabilityImplementation()
-    capability.capability_name = "CountingExample"
+    capability.capability_name = 'CountingExample'
     service = IntersectService([capability], config)
     logger.info('Starting counting_service, use Ctrl+C to exit.')
 

--- a/examples/2_counting_events/counting_service.py
+++ b/examples/2_counting_events/counting_service.py
@@ -83,7 +83,8 @@ if __name__ == '__main__':
         **from_config_file,
     )
     capability = CountingServiceCapabilityImplementation()
-    service = IntersectService(capability, config)
+    capability.capability_name = "CountingExample"
+    service = IntersectService([capability], config)
     logger.info('Starting counting_service, use Ctrl+C to exit.')
 
     """

--- a/examples/3_ping_pong_events/ping_service.py
+++ b/examples/3_ping_pong_events/ping_service.py
@@ -11,7 +11,7 @@ from .service_runner import P_ngBaseCapabilityImplementation, run_service
 logging.basicConfig(level=logging.INFO)
 
 
-class PingCapabiilityImplementation(P_ngBaseCapabilityImplementation):
+class PingCapabilityImplementation(P_ngBaseCapabilityImplementation):
     """Basic capability definition, very similar to the other capability except for the type of event it emits."""
 
     def after_service_startup(self) -> None:
@@ -32,4 +32,4 @@ class PingCapabiilityImplementation(P_ngBaseCapabilityImplementation):
 
 
 if __name__ == '__main__':
-    run_service(PingCapabiilityImplementation())
+    run_service(PingCapabilityImplementation())

--- a/examples/3_ping_pong_events/pong_service.py
+++ b/examples/3_ping_pong_events/pong_service.py
@@ -11,7 +11,7 @@ from .service_runner import P_ngBaseCapabilityImplementation, run_service
 logging.basicConfig(level=logging.INFO)
 
 
-class PongCapabiilityImplementation(P_ngBaseCapabilityImplementation):
+class PongCapabilityImplementation(P_ngBaseCapabilityImplementation):
     """Basic capability definition, very similar to the other capability except for the type of event it emits."""
 
     def after_service_startup(self) -> None:
@@ -32,4 +32,4 @@ class PongCapabiilityImplementation(P_ngBaseCapabilityImplementation):
 
 
 if __name__ == '__main__':
-    run_service(PongCapabiilityImplementation())
+    run_service(PongCapabilityImplementation())

--- a/examples/3_ping_pong_events/service_runner.py
+++ b/examples/3_ping_pong_events/service_runner.py
@@ -58,7 +58,8 @@ def run_service(capability: P_ngBaseCapabilityImplementation) -> None:
         status_interval=30.0,
         **from_config_file,
     )
-    service = IntersectService(capability, config)
+    capability.capability_name = service_name
+    service = IntersectService([capability], config)
     logger.info('Starting %s_service, use Ctrl+C to exit.', service_name)
 
     """

--- a/examples/3_ping_pong_events_amqp/ping_service.py
+++ b/examples/3_ping_pong_events_amqp/ping_service.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger('pika').setLevel(logging.WARNING)
 
 
-class PingCapabiilityImplementation(P_ngBaseCapabilityImplementation):
+class PingCapabilityImplementation(P_ngBaseCapabilityImplementation):
     """Basic capability definition, very similar to the other capability except for the type of event it emits."""
 
     def after_service_startup(self) -> None:
@@ -33,4 +33,4 @@ class PingCapabiilityImplementation(P_ngBaseCapabilityImplementation):
 
 
 if __name__ == '__main__':
-    run_service(PingCapabiilityImplementation())
+    run_service(PingCapabilityImplementation())

--- a/examples/3_ping_pong_events_amqp/pong_service.py
+++ b/examples/3_ping_pong_events_amqp/pong_service.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger('pika').setLevel(logging.WARNING)
 
 
-class PongCapabiilityImplementation(P_ngBaseCapabilityImplementation):
+class PongCapabilityImplementation(P_ngBaseCapabilityImplementation):
     """Basic capability definition, very similar to the other capability except for the type of event it emits."""
 
     def after_service_startup(self) -> None:
@@ -33,4 +33,4 @@ class PongCapabiilityImplementation(P_ngBaseCapabilityImplementation):
 
 
 if __name__ == '__main__':
-    run_service(PongCapabiilityImplementation())
+    run_service(PongCapabilityImplementation())

--- a/examples/3_ping_pong_events_amqp/service_runner.py
+++ b/examples/3_ping_pong_events_amqp/service_runner.py
@@ -58,7 +58,8 @@ def run_service(capability: P_ngBaseCapabilityImplementation) -> None:
         status_interval=30.0,
         **from_config_file,
     )
-    service = IntersectService(capability, config)
+    capability.capability_name = service_name
+    service = IntersectService([capability], config)
     logger.info('Starting %s_service, use Ctrl+C to exit.', service_name)
 
     """

--- a/examples/4_service_to_service/example_1_service.py
+++ b/examples/4_service_to_service/example_1_service.py
@@ -1,0 +1,78 @@
+"""First Service for example. Sends a message to service two and emits an event for the client."""
+
+import logging
+
+from intersect_sdk import (
+    HierarchyConfig,
+    IntersectBaseCapabilityImplementation,
+    IntersectDirectMessageParams,
+    IntersectEventDefinition,
+    IntersectService,
+    IntersectServiceConfig,
+    default_intersect_lifecycle_loop,
+    intersect_event,
+    intersect_message,
+    intersect_status,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class ExampleServiceOneCapabilityImplementation(IntersectBaseCapabilityImplementation):
+    """Service One Capability."""
+
+    @intersect_status()
+    def status(self) -> str:
+        """Basic status function which returns a hard-coded string."""
+        return 'Up'
+
+    @intersect_message()
+    def pass_text_to_service_2(self, text: str) -> None:
+        """Takes in a string parameter and sends it to service 2."""
+        logger.info('maing it to service one')
+        msg_to_send = IntersectDirectMessageParams(
+            destination='example-organization.example-facility.example-system.example-subsystem.service-two',
+            operation='ServiceTwo.test_service',
+            payload=text,
+        )
+
+        # Send intersect message to another service
+        self.intersect_sdk_call_service(msg_to_send, self.service_2_handler)
+
+    @intersect_event(events={'response_event': IntersectEventDefinition(event_type=str)})
+    def service_2_handler(self, msg: str) -> None:
+        """Handles response from service two and emites the response as an event for the client."""
+        logger.info('maing it to right before emitting event')
+        self.intersect_sdk_emit_event('response_event', f'Received Response from Service 2: {msg}')
+
+
+if __name__ == '__main__':
+    from_config_file = {
+        'brokers': [
+            {
+                'username': 'intersect_username',
+                'password': 'intersect_password',
+                'port': 1883,
+                'protocol': 'mqtt3.1.1',
+            },
+        ],
+    }
+    config = IntersectServiceConfig(
+        hierarchy=HierarchyConfig(
+            organization='example-organization',
+            facility='example-facility',
+            system='example-system',
+            subsystem='example-subsystem',
+            service='service-one',
+        ),
+        status_interval=30.0,
+        **from_config_file,
+    )
+    capability = ExampleServiceOneCapabilityImplementation()
+    capability.capability_name = 'ServiceOne'
+    service = IntersectService([capability], config)
+    logger.info('Starting service one, use Ctrl+C to exit.')
+    default_intersect_lifecycle_loop(
+        service,
+    )

--- a/examples/4_service_to_service/example_1_service.py
+++ b/examples/4_service_to_service/example_1_service.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExampleServiceOneCapabilityImplementation(IntersectBaseCapabilityImplementation):
-    """Service One Capability."""
+    """Service 1 Capability."""
 
     @intersect_status()
     def status(self) -> str:
@@ -30,7 +30,6 @@ class ExampleServiceOneCapabilityImplementation(IntersectBaseCapabilityImplement
     @intersect_message()
     def pass_text_to_service_2(self, text: str) -> None:
         """Takes in a string parameter and sends it to service 2."""
-        logger.info('maing it to service one')
         msg_to_send = IntersectDirectMessageParams(
             destination='example-organization.example-facility.example-system.example-subsystem.service-two',
             operation='ServiceTwo.test_service',
@@ -42,8 +41,7 @@ class ExampleServiceOneCapabilityImplementation(IntersectBaseCapabilityImplement
 
     @intersect_event(events={'response_event': IntersectEventDefinition(event_type=str)})
     def service_2_handler(self, msg: str) -> None:
-        """Handles response from service two and emites the response as an event for the client."""
-        logger.info('maing it to right before emitting event')
+        """Handles response from service 2 and emits the response as an event for the client."""
         self.intersect_sdk_emit_event('response_event', f'Received Response from Service 2: {msg}')
 
 
@@ -72,7 +70,7 @@ if __name__ == '__main__':
     capability = ExampleServiceOneCapabilityImplementation()
     capability.capability_name = 'ServiceOne'
     service = IntersectService([capability], config)
-    logger.info('Starting service one, use Ctrl+C to exit.')
+    logger.info('Starting Service 1, use Ctrl+C to exit.')
     default_intersect_lifecycle_loop(
         service,
     )

--- a/examples/4_service_to_service/example_1_service_schema.json
+++ b/examples/4_service_to_service/example_1_service_schema.json
@@ -1,0 +1,174 @@
+{
+    "asyncapi": "2.6.0",
+    "x-intersect-version": "0.6.4",
+    "info": {
+      "title": "example-organization.example-facility.example-system.example-subsystem.service-one",
+      "version": "0.0.0",
+      "description": "Service One Capability.\n"
+    },
+    "defaultContentType": "application/json",
+    "channels": {
+      "pass_text_to_service_2": {
+        "publish": {
+          "message": {
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=2.6.0",
+            "contentType": "application/json",
+            "traits": {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            },
+            "payload": {
+              "type": "null"
+            }
+          },
+          "description": "Takes in a string parameter and sends it to service 2."
+        },
+        "subscribe": {
+          "message": {
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=2.6.0",
+            "contentType": "application/json",
+            "traits": {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            },
+            "payload": {
+              "type": "string"
+            }
+          },
+          "description": "Takes in a string parameter and sends it to service 2."
+        },
+        "events": []
+      }
+    },
+    "events": {
+      "response_event": {
+        "type": "string"
+      }
+    },
+    "components": {
+      "schemas": {},
+      "messageTraits": {
+        "commonHeaders": {
+          "messageHeaders": {
+            "$defs": {
+              "IntersectDataHandler": {
+                "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+                "enum": [
+                  0,
+                  1
+                ],
+                "title": "IntersectDataHandler",
+                "type": "integer"
+              }
+            },
+            "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+            "properties": {
+              "source": {
+                "description": "source of the message",
+                "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+                "title": "Source",
+                "type": "string"
+              },
+              "destination": {
+                "description": "destination of the message",
+                "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+                "title": "Destination",
+                "type": "string"
+              },
+              "created_at": {
+                "description": "the UTC timestamp of message creation",
+                "format": "date-time",
+                "title": "Created At",
+                "type": "string"
+              },
+              "sdk_version": {
+                "description": "SemVer string of SDK's version, used to check for compatibility",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "title": "Sdk Version",
+                "type": "string"
+              },
+              "data_handler": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/messageTraits/commonHeaders/userspaceHeaders/$defs/IntersectDataHandler"
+                  }
+                ],
+                "default": 0,
+                "description": "Code signifying where data is stored."
+              },
+              "has_error": {
+                "default": false,
+                "description": "If this value is True, the payload will contain the error message (a string)",
+                "title": "Has Error",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "source",
+              "destination",
+              "created_at",
+              "sdk_version"
+            ],
+            "title": "UserspaceMessageHeader",
+            "type": "object"
+          },
+          "eventHeaders": {
+            "$defs": {
+              "IntersectDataHandler": {
+                "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+                "enum": [
+                  0,
+                  1
+                ],
+                "title": "IntersectDataHandler",
+                "type": "integer"
+              }
+            },
+            "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+            "properties": {
+              "source": {
+                "description": "source of the message",
+                "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+                "title": "Source",
+                "type": "string"
+              },
+              "created_at": {
+                "description": "the UTC timestamp of message creation",
+                "format": "date-time",
+                "title": "Created At",
+                "type": "string"
+              },
+              "sdk_version": {
+                "description": "SemVer string of SDK's version, used to check for compatibility",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "title": "Sdk Version",
+                "type": "string"
+              },
+              "data_handler": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/messageTraits/commonHeaders/eventHeaders/$defs/IntersectDataHandler"
+                  }
+                ],
+                "default": 0,
+                "description": "Code signifying where data is stored."
+              },
+              "event_name": {
+                "title": "Event Name",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "created_at",
+              "sdk_version",
+              "event_name"
+            ],
+            "title": "EventMessageHeaders",
+            "type": "object"
+          }
+        }
+      }
+    },
+    "status": {
+      "type": "string"
+    }
+  }

--- a/examples/4_service_to_service/example_2_service.py
+++ b/examples/4_service_to_service/example_2_service.py
@@ -1,0 +1,62 @@
+"""Second Service for example."""
+
+import logging
+
+from intersect_sdk import (
+    HierarchyConfig,
+    IntersectBaseCapabilityImplementation,
+    IntersectService,
+    IntersectServiceConfig,
+    default_intersect_lifecycle_loop,
+    intersect_message,
+    intersect_status,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class ExampleServiceTwoCapabilityImplementation(IntersectBaseCapabilityImplementation):
+    """Service Two Capability."""
+
+    @intersect_status()
+    def status(self) -> str:
+        """Basic status function which returns a hard-coded string."""
+        return 'Up'
+
+    @intersect_message
+    def test_service(self, text: str) -> str:
+        """Returns the text given along with acknowledgement."""
+        logger.info('Making it to service 2')
+        return f'Acknowledging service one text -> {text}'
+
+
+if __name__ == '__main__':
+    from_config_file = {
+        'brokers': [
+            {
+                'username': 'intersect_username',
+                'password': 'intersect_password',
+                'port': 1883,
+                'protocol': 'mqtt3.1.1',
+            },
+        ],
+    }
+    config = IntersectServiceConfig(
+        hierarchy=HierarchyConfig(
+            organization='example-organization',
+            facility='example-facility',
+            system='example-system',
+            subsystem='example-subsystem',
+            service='service-two',
+        ),
+        status_interval=30.0,
+        **from_config_file,
+    )
+    capability = ExampleServiceTwoCapabilityImplementation()
+    capability.capability_name = 'ServiceTwo'
+    service = IntersectService([capability], config)
+    logger.info('Starting service two, use Ctrl+C to exit.')
+    default_intersect_lifecycle_loop(
+        service,
+    )

--- a/examples/4_service_to_service/example_2_service.py
+++ b/examples/4_service_to_service/example_2_service.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExampleServiceTwoCapabilityImplementation(IntersectBaseCapabilityImplementation):
-    """Service Two Capability."""
+    """Service 2 Capability."""
 
     @intersect_status()
     def status(self) -> str:
@@ -27,7 +27,6 @@ class ExampleServiceTwoCapabilityImplementation(IntersectBaseCapabilityImplement
     @intersect_message
     def test_service(self, text: str) -> str:
         """Returns the text given along with acknowledgement."""
-        logger.info('Making it to service 2')
         return f'Acknowledging service one text -> {text}'
 
 
@@ -56,7 +55,7 @@ if __name__ == '__main__':
     capability = ExampleServiceTwoCapabilityImplementation()
     capability.capability_name = 'ServiceTwo'
     service = IntersectService([capability], config)
-    logger.info('Starting service two, use Ctrl+C to exit.')
+    logger.info('Starting Service 2, use Ctrl+C to exit.')
     default_intersect_lifecycle_loop(
         service,
     )

--- a/examples/4_service_to_service/example_2_service_schema.json
+++ b/examples/4_service_to_service/example_2_service_schema.json
@@ -1,0 +1,170 @@
+{
+    "asyncapi": "2.6.0",
+    "x-intersect-version": "0.6.4",
+    "info": {
+      "title": "example-organization.example-facility.example-system.example-subsystem.service-two",
+      "version": "0.0.0",
+      "description": "Service Two Capability.\n"
+    },
+    "defaultContentType": "application/json",
+    "channels": {
+      "test_service": {
+        "publish": {
+          "message": {
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=2.6.0",
+            "contentType": "application/json",
+            "traits": {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            },
+            "payload": {
+              "type": "string"
+            }
+          },
+          "description": "Returns the text given along with acknowledgement."
+        },
+        "subscribe": {
+          "message": {
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=2.6.0",
+            "contentType": "application/json",
+            "traits": {
+              "$ref": "#/components/messageTraits/commonHeaders"
+            },
+            "payload": {
+              "type": "string"
+            }
+          },
+          "description": "Returns the text given along with acknowledgement."
+        },
+        "events": []
+      }
+    },
+    "events": {},
+    "components": {
+      "schemas": {},
+      "messageTraits": {
+        "commonHeaders": {
+          "messageHeaders": {
+            "$defs": {
+              "IntersectDataHandler": {
+                "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+                "enum": [
+                  0,
+                  1
+                ],
+                "title": "IntersectDataHandler",
+                "type": "integer"
+              }
+            },
+            "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+            "properties": {
+              "source": {
+                "description": "source of the message",
+                "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+                "title": "Source",
+                "type": "string"
+              },
+              "destination": {
+                "description": "destination of the message",
+                "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+                "title": "Destination",
+                "type": "string"
+              },
+              "created_at": {
+                "description": "the UTC timestamp of message creation",
+                "format": "date-time",
+                "title": "Created At",
+                "type": "string"
+              },
+              "sdk_version": {
+                "description": "SemVer string of SDK's version, used to check for compatibility",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "title": "Sdk Version",
+                "type": "string"
+              },
+              "data_handler": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/messageTraits/commonHeaders/userspaceHeaders/$defs/IntersectDataHandler"
+                  }
+                ],
+                "default": 0,
+                "description": "Code signifying where data is stored."
+              },
+              "has_error": {
+                "default": false,
+                "description": "If this value is True, the payload will contain the error message (a string)",
+                "title": "Has Error",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "source",
+              "destination",
+              "created_at",
+              "sdk_version"
+            ],
+            "title": "UserspaceMessageHeader",
+            "type": "object"
+          },
+          "eventHeaders": {
+            "$defs": {
+              "IntersectDataHandler": {
+                "description": "What data transfer type do you want to use for handling the request/response?\n\nDefault: MESSAGE",
+                "enum": [
+                  0,
+                  1
+                ],
+                "title": "IntersectDataHandler",
+                "type": "integer"
+              }
+            },
+            "description": "Matches the current header definition for INTERSECT messages.\n\nALL messages should contain this header.",
+            "properties": {
+              "source": {
+                "description": "source of the message",
+                "pattern": "([-a-z0-9]+\\.)*[-a-z0-9]",
+                "title": "Source",
+                "type": "string"
+              },
+              "created_at": {
+                "description": "the UTC timestamp of message creation",
+                "format": "date-time",
+                "title": "Created At",
+                "type": "string"
+              },
+              "sdk_version": {
+                "description": "SemVer string of SDK's version, used to check for compatibility",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "title": "Sdk Version",
+                "type": "string"
+              },
+              "data_handler": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/messageTraits/commonHeaders/eventHeaders/$defs/IntersectDataHandler"
+                  }
+                ],
+                "default": 0,
+                "description": "Code signifying where data is stored."
+              },
+              "event_name": {
+                "title": "Event Name",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "created_at",
+              "sdk_version",
+              "event_name"
+            ],
+            "title": "EventMessageHeaders",
+            "type": "object"
+          }
+        }
+      }
+    },
+    "status": {
+      "type": "string"
+    }
+  }

--- a/examples/4_service_to_service/example_client.py
+++ b/examples/4_service_to_service/example_client.py
@@ -21,12 +21,12 @@ logger = logging.getLogger(__name__)
 
 
 class SampleOrchestrator:
-    """Simply contains an event callback for events from Service One."""
+    """Simply contains an event callback for events from Service 1."""
 
     def event_callback(
         self, _source: str, _operation: str, _event_name: str, payload: INTERSECT_JSON_VALUE
     ) -> None:
-        """This simply prints the event from Service One  to your console.
+        """This simply prints the event from Service 1 to your console.
 
         Params:
           source: the source of the response message.
@@ -34,7 +34,6 @@ class SampleOrchestrator:
           _has_error: Boolean value which represents an error.
           payload: Value of the response from the Service.
         """
-        logger.info('making it to event callback')
         print(payload)
 
 

--- a/examples/4_service_to_service/example_client.py
+++ b/examples/4_service_to_service/example_client.py
@@ -1,0 +1,78 @@
+"""Client for service to service example.
+
+Kicks off exmaple by sending message to service one, and then
+waits for an event from service one to confirm the messages were passed between the two services properly.
+
+"""
+
+import logging
+
+from intersect_sdk import (
+    INTERSECT_JSON_VALUE,
+    IntersectClient,
+    IntersectClientCallback,
+    IntersectClientConfig,
+    IntersectDirectMessageParams,
+    default_intersect_lifecycle_loop,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class SampleOrchestrator:
+    """Simply contains an event callback for events from Service One."""
+
+    def event_callback(
+        self, _source: str, _operation: str, _event_name: str, payload: INTERSECT_JSON_VALUE
+    ) -> None:
+        """This simply prints the event from Service One  to your console.
+
+        Params:
+          source: the source of the response message.
+          operation: the name of the function we called in the original message.
+          _has_error: Boolean value which represents an error.
+          payload: Value of the response from the Service.
+        """
+        logger.info('making it to event callback')
+        print(payload)
+
+
+if __name__ == '__main__':
+    from_config_file = {
+        'brokers': [
+            {
+                'username': 'intersect_username',
+                'password': 'intersect_password',
+                'port': 1883,
+                'protocol': 'mqtt3.1.1',
+            },
+        ],
+    }
+
+    # The counter will start after the initial message.
+    # If the service is already active and counting, this may do nothing.
+    initial_messages = [
+        IntersectDirectMessageParams(
+            destination='example-organization.example-facility.example-system.example-subsystem.service-one',
+            operation='ServiceOne.pass_text_to_service_2',
+            payload='Kicking off the example!',
+        )
+    ]
+    config = IntersectClientConfig(
+        initial_message_event_config=IntersectClientCallback(
+            messages_to_send=initial_messages,
+            services_to_start_listening_for_events=[
+                'example-organization.example-facility.example-system.example-subsystem.service-one'
+            ],
+        ),
+        **from_config_file,
+    )
+    orchestrator = SampleOrchestrator()
+    client = IntersectClient(
+        config=config,
+        event_callback=orchestrator.event_callback,
+    )
+    default_intersect_lifecycle_loop(
+        client,
+    )

--- a/examples/4_service_to_service/example_client.py
+++ b/examples/4_service_to_service/example_client.py
@@ -35,6 +35,8 @@ class SampleOrchestrator:
           payload: Value of the response from the Service.
         """
         print(payload)
+        # break out of pubsub loop
+        raise Exception
 
 
 if __name__ == '__main__':

--- a/examples/SUBMISSION_RULES.md
+++ b/examples/SUBMISSION_RULES.md
@@ -77,7 +77,7 @@ import json
 
 if __name__ == '__main__':
     # everything before service creation omitted
-    service = IntersectService(capability, config)
+    service = IntersectService([capability], config)
     print(json.dumps(service._schema, indent=2))
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ isort = { known-first-party = ['src'] }
 pydocstyle = { convention = 'google'}
 flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
 mccabe = { max-complexity = 20 }
-pylint = { max-args = 10, max-branches = 20, max-returns = 10 }
+pylint = { max-args = 10, max-branches = 20, max-returns = 10, max-statements = 75 }
 # pyflakes and the relevant pycodestyle rules are already configured
 extend-select = [
     'C90', # mccabe complexity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ test = [
 test-all = "pytest tests/ --cov=src/intersect_sdk/ --cov-fail-under=80 --cov-report=html:reports/htmlcov/ --cov-report=xml:reports/coverage_report.xml --junitxml=reports/junit.xml"
 test-all-debug = "pytest tests/ --cov=src/intersect_sdk/ --cov-fail-under=80 --cov-report=html:reports/htmlcov/ --cov-report=xml:reports/coverage_report.xml --junitxml=reports/junit.xml -s"
 test-unit = "pytest tests/unit --cov=src/intersect_sdk/"
+test-e2e = "pytest tests/e2e --cov=src/intersect_sdk/"
 lint = {composite = ["lint-format", "lint-ruff", "lint-mypy"]}
 lint-format = "ruff format"
 lint-ruff = "ruff check --fix"

--- a/src/intersect_sdk/__init__.py
+++ b/src/intersect_sdk/__init__.py
@@ -37,7 +37,7 @@ from .service_definitions import (
 )
 from .shared_callback_definitions import (
     INTERSECT_JSON_VALUE,
-    DirectMessageParams,
+    IntersectDirectMessageParams,
 )
 from .version import __version__, version_info, version_string
 
@@ -52,7 +52,7 @@ __all__ = [
     'IntersectService',
     'IntersectClient',
     'IntersectClientCallback',
-    'DirectMessageParams',
+    'IntersectDirectMessageParams',
     'INTERSECT_CLIENT_RESPONSE_CALLBACK_TYPE',
     'INTERSECT_CLIENT_EVENT_CALLBACK_TYPE',
     'INTERSECT_JSON_VALUE',

--- a/src/intersect_sdk/__init__.py
+++ b/src/intersect_sdk/__init__.py
@@ -13,9 +13,7 @@ from .client import IntersectClient
 from .client_callback_definitions import (
     INTERSECT_CLIENT_EVENT_CALLBACK_TYPE,
     INTERSECT_CLIENT_RESPONSE_CALLBACK_TYPE,
-    INTERSECT_JSON_VALUE,
     IntersectClientCallback,
-    IntersectClientMessageParams,
 )
 from .config.client import IntersectClientConfig
 from .config.service import IntersectServiceConfig
@@ -28,11 +26,18 @@ from .config.shared import (
 from .core_definitions import IntersectDataHandler, IntersectMimeType
 from .schema import get_schema_from_capability_implementation
 from .service import IntersectService
+from .service_callback_definitions import (
+    INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE,
+)
 from .service_definitions import (
     IntersectEventDefinition,
     intersect_event,
     intersect_message,
     intersect_status,
+)
+from .shared_callback_definitions import (
+    INTERSECT_JSON_VALUE,
+    DirectMessageParams,
 )
 from .version import __version__, version_info, version_string
 
@@ -47,10 +52,11 @@ __all__ = [
     'IntersectService',
     'IntersectClient',
     'IntersectClientCallback',
-    'IntersectClientMessageParams',
+    'DirectMessageParams',
     'INTERSECT_CLIENT_RESPONSE_CALLBACK_TYPE',
     'INTERSECT_CLIENT_EVENT_CALLBACK_TYPE',
     'INTERSECT_JSON_VALUE',
+    'INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE',
     'IntersectBaseCapabilityImplementation',
     'default_intersect_lifecycle_loop',
     'IntersectClientConfig',

--- a/src/intersect_sdk/_internal/function_metadata.py
+++ b/src/intersect_sdk/_internal/function_metadata.py
@@ -12,6 +12,10 @@ class FunctionMetadata(NamedTuple):
     NOTE: both this class and all properties in it should remain immutable after creation
     """
 
+    capability: type
+    """
+    The type of the class that implements the target method.
+    """
     method: Callable[[Any], Any]
     """
     The raw method of the function. The function itself is useless and should not be called,

--- a/src/intersect_sdk/_internal/interfaces.py
+++ b/src/intersect_sdk/_internal/interfaces.py
@@ -1,5 +1,17 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from ..service_callback_definitions import (
+        INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE,
+    )
+    from ..shared_callback_definitions import (
+        DirectMessageParams,
+    )
 
 
 class IntersectEventObserver(ABC):
@@ -16,5 +28,22 @@ class IntersectEventObserver(ABC):
             event_name: The key of the event which is fired.
             event_value: The value of the event which is fired.
             operation: The source of the event (generally the function name, not directly invoked by application devs)
+        """
+        ...
+
+    @abstractmethod
+    def create_external_request(
+        self,
+        request: DirectMessageParams,
+        response_handler: INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None = None,
+    ) -> UUID:
+        """Observed entity (capabilitiy) tells observer (i.e. service) to send an external request.
+
+        Params:
+          - request: the request we want to send out, encapsulated as an IntersectClientMessageParams object
+          - response_handler: optional callback for how we want to handle the response from this request.
+
+        Returns:
+          - generated RequestID associated with your request
         """
         ...

--- a/src/intersect_sdk/_internal/interfaces.py
+++ b/src/intersect_sdk/_internal/interfaces.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
         INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE,
     )
     from ..shared_callback_definitions import (
-        DirectMessageParams,
+        IntersectDirectMessageParams,
     )
 
 
@@ -34,7 +34,7 @@ class IntersectEventObserver(ABC):
     @abstractmethod
     def create_external_request(
         self,
-        request: DirectMessageParams,
+        request: IntersectDirectMessageParams,
         response_handler: INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None = None,
     ) -> UUID:
         """Observed entity (capabilitiy) tells observer (i.e. service) to send an external request.

--- a/src/intersect_sdk/_internal/messages/userspace.py
+++ b/src/intersect_sdk/_internal/messages/userspace.py
@@ -2,6 +2,13 @@
 
 This module is internal-facing and should not be used directly by users.
 
+Services have two associated channels which handle userspace messages: their request channel
+and their response channel. Services always CONSUME messages from these channels, but never PRODUCE messages
+on these channels. (A message is always sent in the receiver's namespace).
+
+The response channel is how the service handles external requests, the request channel is used when this service itself
+needs to make external requests through INTERSECT.
+
 Services should ALWAYS be CONSUMING from their userspace channel.
 They should NEVER be PRODUCING messages on their userspace channel.
 

--- a/src/intersect_sdk/_internal/messages/userspace.py
+++ b/src/intersect_sdk/_internal/messages/userspace.py
@@ -141,11 +141,13 @@ def create_userspace_message(
     content_type: IntersectMimeType,
     data_handler: IntersectDataHandler,
     payload: Any,
+    message_id: uuid.UUID = None,
     has_error: bool = False,
 ) -> UserspaceMessage:
     """Payloads depend on the data_handler and has_error."""
+    msg_id = message_id if message_id else uuid.uuid4()
     return UserspaceMessage(
-        messageId=uuid.uuid4(),
+        messageId=msg_id,
         operationId=operation_id,
         contentType=content_type,
         payload=payload,

--- a/src/intersect_sdk/_internal/messages/userspace.py
+++ b/src/intersect_sdk/_internal/messages/userspace.py
@@ -9,6 +9,8 @@ Clients should be CONSUMING from their userspace channel, but should only get me
 from services they explicitly messaged.
 """
 
+from __future__ import annotations
+
 import datetime
 import uuid
 from typing import Any, Union
@@ -16,10 +18,13 @@ from typing import Any, Union
 from pydantic import AwareDatetime, Field, TypeAdapter
 from typing_extensions import Annotated, TypedDict
 
-from ...constants import SYSTEM_OF_SYSTEM_REGEX
-from ...core_definitions import IntersectDataHandler, IntersectMimeType
+from ...constants import SYSTEM_OF_SYSTEM_REGEX  # noqa: TCH001 (this is runtime checked)
+from ...core_definitions import (  # noqa: TCH001 (this is runtime checked)
+    IntersectDataHandler,
+    IntersectMimeType,
+)
 from ...version import version_string
-from ..data_plane.minio_utils import MinioPayload
+from ..data_plane.minio_utils import MinioPayload  # noqa: TCH001 (this is runtime checked)
 
 
 class UserspaceMessageHeader(TypedDict):
@@ -115,7 +120,7 @@ class UserspaceMessage(TypedDict):
     the headers of the message
     """
 
-    payload: Union[bytes, MinioPayload]  # noqa: FA100 (Pydantic uses runtime annotations)
+    payload: Union[bytes, MinioPayload]  # noqa: UP007 (Pydantic uses runtime annotations)
     """
     main payload of the message. Needs to match the schema format, including the content type.
 
@@ -141,7 +146,7 @@ def create_userspace_message(
     content_type: IntersectMimeType,
     data_handler: IntersectDataHandler,
     payload: Any,
-    message_id: uuid.UUID = None,
+    message_id: uuid.UUID | None = None,
     has_error: bool = False,
 ) -> UserspaceMessage:
     """Payloads depend on the data_handler and has_error."""

--- a/src/intersect_sdk/_internal/schema.py
+++ b/src/intersect_sdk/_internal/schema.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    List,
     Mapping,
     NamedTuple,
     get_origin,
@@ -339,7 +338,7 @@ def _introspection_baseline(
     # parse functions
     for class_name, name, method, min_params in response_funcs:
         public_name = f'{cap_name}.{name}'
-        
+
         # TODO - I'm placing this here for now because we'll eventually want to capture data plane and broker configs in the schema.
         # (It's possible we may want to separate the backing service schema from the application logic, but it's unlikely.)
         # At the moment, we're just validating that users can support their response_data_handler property.
@@ -495,7 +494,7 @@ def _introspection_baseline(
 
 
 def get_schema_and_functions_from_capability_implementations(
-    capabilities: List[IntersectBaseCapabilityImplementation],
+    capabilities: list[IntersectBaseCapabilityImplementation],
     service_name: HierarchyConfig,
     excluded_data_handlers: set[IntersectDataHandler],
 ) -> tuple[
@@ -510,16 +509,16 @@ def get_schema_and_functions_from_capability_implementations(
 
     In-depth introspection is handled later on.
     """
-    capability_type_docs : str = ""
-    status_function_cap : IntersectBaseCapabilityImplementation = None
-    status_function_name : str = None
-    status_function_schema : dict[str, Any] = None
-    status_function_adapter : TypeAdapter[Any] = None
-    schemas : dict[Any, Any] = dict()
-    channels : dict[str, dict[str, dict[str, Any]]] = dict() # endpoint schemas
-    function_map : dict[str, FunctionMetadata] = dict()      # endpoint functionality
-    events : dict[str, Any] = dict()                         # event schemas
-    event_map : dict[str, EventMetadata] = dict()            # event functionality
+    capability_type_docs: str = ''
+    status_function_cap: IntersectBaseCapabilityImplementation | None = None
+    status_function_name: str | None = None
+    status_function_schema: dict[str, Any] | None = None
+    status_function_adapter: TypeAdapter[Any] | None = None
+    schemas: dict[Any, Any] = {}
+    channels: dict[str, dict[str, dict[str, Any]]] = {}  # endpoint schemas
+    function_map: dict[str, FunctionMetadata] = {}  # endpoint functionality
+    events: dict[str, Any] = {}  # event schemas
+    event_map: dict[str, EventMetadata] = {}  # event functionality
     for capability in capabilities:
         capability_type: type[IntersectBaseCapabilityImplementation] = type(capability)
         if capability_type.__doc__:
@@ -532,7 +531,7 @@ def get_schema_and_functions_from_capability_implementations(
             cap_events,
             cap_event_map,
         ) = _introspection_baseline(capability, excluded_data_handlers)
-        
+
         if cap_status_fn_name and cap_status_schema and cap_status_type_adapter:
             status_function_cap = capability
             status_function_name = cap_status_fn_name
@@ -544,7 +543,6 @@ def get_schema_and_functions_from_capability_implementations(
         function_map.update(cap_function_map)
         events.update(cap_events)
         event_map.update(cap_event_map)
-        
 
     asyncapi_spec = {
         'asyncapi': ASYNCAPI_VERSION,
@@ -576,7 +574,7 @@ def get_schema_and_functions_from_capability_implementations(
         },
     }
 
-    if capability_type_docs != "":
+    if capability_type_docs != '':
         asyncapi_spec['info']['description'] = capability_type_docs  # type: ignore[index]
 
     if status_function_schema:
@@ -591,4 +589,11 @@ def get_schema_and_functions_from_capability_implementations(
     },
     """
 
-    return asyncapi_spec, function_map, event_map, status_function_cap, status_function_name, status_function_adapter
+    return (
+        asyncapi_spec,
+        function_map,
+        event_map,
+        status_function_cap,
+        status_function_name,
+        status_function_adapter,
+    )

--- a/src/intersect_sdk/capability/base.py
+++ b/src/intersect_sdk/capability/base.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
         INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE,
     )
     from ..shared_callback_definitions import (
-        DirectMessageParams,
+        IntersectDirectMessageParams,
     )
 
 
@@ -131,7 +131,7 @@ class IntersectBaseCapabilityImplementation:
     @final
     def intersect_sdk_call_service(
         self,
-        request: DirectMessageParams,
+        request: IntersectDirectMessageParams,
         response_handler: INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None = None,
     ) -> list[UUID]:
         """Create an external request that we'll send to a different Service.

--- a/src/intersect_sdk/capability/base.py
+++ b/src/intersect_sdk/capability/base.py
@@ -26,13 +26,13 @@ class IntersectBaseCapabilityImplementation:
     """Base class for all capabilities.
 
     EVERY capability implementation will need to extend this class. Additionally, if you redefine the constructor,
-    you MUST call super.__init__() .
+    you MUST call `super.__init__()` .
     """
 
     def __init__(self) -> None:
         """This constructor just sets up observers.
 
-        NOTE: If you write your own constructor, you MUST call super.__init__() inside of it. The Service will throw an error if you don't.
+        NOTE: If you write your own constructor, you MUST call `super.__init__()` inside of it. The Service will throw an error if you don't.
         """
         self._capability_name: str = 'InvalidCapability'
         """
@@ -49,7 +49,7 @@ class IntersectBaseCapabilityImplementation:
     def __init_subclass__(cls) -> None:
         """This prevents users from overriding a few key functions.
 
-        General rule of thumb is that any function which starts with "intersect_sdk_" is a protected namespace for defining
+        General rule of thumb is that any function which starts with `intersect_sdk_` is a protected namespace for defining
         the INTERSECT-SDK public API between a capability and its observers.
         """
         if (

--- a/src/intersect_sdk/capability/base.py
+++ b/src/intersect_sdk/capability/base.py
@@ -26,8 +26,7 @@ class IntersectBaseCapabilityImplementation:
 
         NOTE: If you write your own constructor, you MUST call super.__init__() inside of it. The Service will throw an error if you don't.
         """
-        
-        self._capability_name : str = "InvalidCapability"
+        self._capability_name: str = 'InvalidCapability'
         """
         The advertised name for the capability, as opposed to the implementation class name
         """
@@ -49,14 +48,14 @@ class IntersectBaseCapabilityImplementation:
         ):
             msg = f"{cls.__name__}: Cannot override functions '_intersect_sdk_register_observer' or 'intersect_sdk_emit_event'"
             raise RuntimeError(msg)
-        
+
     @property
     def capability_name(self) -> str:
-        """The advertised name for the capability provided by this implementation"""
+        """The advertised name for the capability provided by this implementation."""
         return self._capability_name
-    
+
     @capability_name.setter
-    def capability_name(self, cname : str) -> str:
+    def capability_name(self, cname: str) -> None:
         self._capability_name = cname
 
     @final

--- a/src/intersect_sdk/capability/base.py
+++ b/src/intersect_sdk/capability/base.py
@@ -26,6 +26,12 @@ class IntersectBaseCapabilityImplementation:
 
         NOTE: If you write your own constructor, you MUST call super.__init__() inside of it. The Service will throw an error if you don't.
         """
+        
+        self._capability_name : str = "InvalidCapability"
+        """
+        The advertised name for the capability, as opposed to the implementation class name
+        """
+
         self.__intersect_sdk_observers__: list[IntersectEventObserver] = []
         """
         INTERNAL USE ONLY.
@@ -43,6 +49,15 @@ class IntersectBaseCapabilityImplementation:
         ):
             msg = f"{cls.__name__}: Cannot override functions '_intersect_sdk_register_observer' or 'intersect_sdk_emit_event'"
             raise RuntimeError(msg)
+        
+    @property
+    def capability_name(self) -> str:
+        """The advertised name for the capability provided by this implementation"""
+        return self._capability_name
+    
+    @capability_name.setter
+    def capability_name(self, cname : str) -> str:
+        self._capability_name = cname
 
     @final
     def _intersect_sdk_register_observer(self, observer: IntersectEventObserver) -> None:

--- a/src/intersect_sdk/client.py
+++ b/src/intersect_sdk/client.py
@@ -40,7 +40,6 @@ from ._internal.utils import die, send_os_signal
 from ._internal.version_resolver import resolve_user_version
 from .client_callback_definitions import (
     IntersectClientCallback,
-    IntersectClientMessageParams,
 )
 from .config.client import IntersectClientConfig
 from .config.shared import HierarchyConfig
@@ -50,6 +49,7 @@ if TYPE_CHECKING:
         INTERSECT_CLIENT_EVENT_CALLBACK_TYPE,
         INTERSECT_CLIENT_RESPONSE_CALLBACK_TYPE,
     )
+    from .shared_callback_definitions import DirectMessageParams
 
 
 @final
@@ -425,7 +425,7 @@ class IntersectClient:
         for message in validated_result.messages_to_send:
             self._send_userspace_message(message)
 
-    def _send_userspace_message(self, params: IntersectClientMessageParams) -> None:
+    def _send_userspace_message(self, params: DirectMessageParams) -> None:
         """Send a userspace message, be it an initial message from the user or from the user's callback function."""
         # ONE: SERIALIZE FUNCTION RESULTS
         # (function input should already be validated at this point)

--- a/src/intersect_sdk/client.py
+++ b/src/intersect_sdk/client.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
         INTERSECT_CLIENT_EVENT_CALLBACK_TYPE,
         INTERSECT_CLIENT_RESPONSE_CALLBACK_TYPE,
     )
-    from .shared_callback_definitions import DirectMessageParams
+    from .shared_callback_definitions import IntersectDirectMessageParams
 
 
 @final
@@ -425,7 +425,7 @@ class IntersectClient:
         for message in validated_result.messages_to_send:
             self._send_userspace_message(message)
 
-    def _send_userspace_message(self, params: DirectMessageParams) -> None:
+    def _send_userspace_message(self, params: IntersectDirectMessageParams) -> None:
         """Send a userspace message, be it an initial message from the user or from the user's callback function."""
         # ONE: SERIALIZE FUNCTION RESULTS
         # (function input should already be validated at this point)

--- a/src/intersect_sdk/client_callback_definitions.py
+++ b/src/intersect_sdk/client_callback_definitions.py
@@ -33,14 +33,14 @@ class IntersectClientMessageParams:
     If you want to just use the service's default value for a request (assuming it has a default value for a request), you may set this as None.
     """
 
-    response_content_type: IntersectMimeType = IntersectMimeType.JSON
+    content_type: IntersectMimeType = IntersectMimeType.JSON
     """
-    The IntersectMimeType of your response. You'll want this to match with the ContentType of the function from the schema.
+    The IntersectMimeType of your message. You'll want this to match with the ContentType of the function from the schema.
 
     default: IntersectMimeType.JSON
     """
 
-    response_data_handler: IntersectDataHandler = IntersectDataHandler.MESSAGE
+    data_handler: IntersectDataHandler = IntersectDataHandler.MESSAGE
     """
     The IntersectDataHandler you want to use (most people can just use IntersectDataHandler.MESSAGE here, unless your data is very large)
 

--- a/src/intersect_sdk/client_callback_definitions.py
+++ b/src/intersect_sdk/client_callback_definitions.py
@@ -1,52 +1,15 @@
-"""Data types used in regard to client callbacks. Only relevant for Client authors."""
+"""Data types used in regard to client callbacks. Only relevant for Client authors.
 
-from typing import Any, Callable, Dict, List, Optional, Union
+See shared_callback_definitions for additional typings which are also shared by service authors.
+"""
+
+from typing import Callable, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated, TypeAlias, final
 
 from .constants import SYSTEM_OF_SYSTEM_REGEX
-from .core_definitions import IntersectDataHandler, IntersectMimeType
-
-
-class IntersectClientMessageParams(BaseModel):
-    """The user implementing the IntersectClient class will need to return this object in order to send a message to another Service."""
-
-    destination: Annotated[str, Field(pattern=SYSTEM_OF_SYSTEM_REGEX)]
-    """
-    The destination string. You'll need to know the system-of-system representation of the Service.
-
-    Note that this should match what you would see in the schema.
-    """
-
-    operation: str
-    """
-    The name of the operation you want to call from the Service - this should be represented as it is in the Service's schema.
-    """
-
-    payload: Any
-    """
-    The raw Python object you want to have serialized as the payload.
-
-    If you want to just use the service's default value for a request (assuming it has a default value for a request), you may set this as None.
-    """
-
-    content_type: IntersectMimeType = IntersectMimeType.JSON
-    """
-    The IntersectMimeType of your message. You'll want this to match with the ContentType of the function from the schema.
-
-    default: IntersectMimeType.JSON
-    """
-
-    data_handler: IntersectDataHandler = IntersectDataHandler.MESSAGE
-    """
-    The IntersectDataHandler you want to use (most people can just use IntersectDataHandler.MESSAGE here, unless your data is very large)
-
-    default: IntersectDataHandler.MESSAGE
-    """
-
-    # pydantic config
-    model_config = ConfigDict(revalidate_instances='always')
+from .shared_callback_definitions import DirectMessageParams
 
 
 @final
@@ -56,7 +19,7 @@ class IntersectClientCallback(BaseModel):
     If you do not return a value of this type (or None), this will be treated as an Exception and will break the pub-sub loop.
     """
 
-    messages_to_send: List[IntersectClientMessageParams] = []  # noqa: FA100 (runtime annotation)
+    messages_to_send: List[DirectMessageParams] = []  # noqa: FA100 (runtime annotation)
     """
     Messages to send as a result of an event or a response from a Service.
     """

--- a/src/intersect_sdk/client_callback_definitions.py
+++ b/src/intersect_sdk/client_callback_definitions.py
@@ -1,6 +1,5 @@
 """Data types used in regard to client callbacks. Only relevant for Client authors."""
 
-from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -10,8 +9,7 @@ from .constants import SYSTEM_OF_SYSTEM_REGEX
 from .core_definitions import IntersectDataHandler, IntersectMimeType
 
 
-@dataclass
-class IntersectClientMessageParams:
+class IntersectClientMessageParams(BaseModel):
     """The user implementing the IntersectClient class will need to return this object in order to send a message to another Service."""
 
     destination: Annotated[str, Field(pattern=SYSTEM_OF_SYSTEM_REGEX)]
@@ -46,6 +44,9 @@ class IntersectClientMessageParams:
 
     default: IntersectDataHandler.MESSAGE
     """
+
+    # pydantic config
+    model_config = ConfigDict(revalidate_instances='always')
 
 
 @final

--- a/src/intersect_sdk/client_callback_definitions.py
+++ b/src/intersect_sdk/client_callback_definitions.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated, TypeAlias, final
 
 from .constants import SYSTEM_OF_SYSTEM_REGEX
-from .shared_callback_definitions import DirectMessageParams
+from .shared_callback_definitions import IntersectDirectMessageParams
 
 
 @final
@@ -19,7 +19,7 @@ class IntersectClientCallback(BaseModel):
     If you do not return a value of this type (or None), this will be treated as an Exception and will break the pub-sub loop.
     """
 
-    messages_to_send: List[DirectMessageParams] = []  # noqa: FA100 (runtime annotation)
+    messages_to_send: List[IntersectDirectMessageParams] = []  # noqa: FA100 (runtime annotation)
     """
     Messages to send as a result of an event or a response from a Service.
     """

--- a/src/intersect_sdk/schema.py
+++ b/src/intersect_sdk/schema.py
@@ -33,7 +33,7 @@ from typing import (
     Any,
 )
 
-from ._internal.schema import get_schema_and_functions_from_capability_implementation
+from ._internal.schema import get_schema_and_functions_from_capability_implementations
 
 if TYPE_CHECKING:
     from .capability.base import IntersectBaseCapabilityImplementation
@@ -42,13 +42,13 @@ if TYPE_CHECKING:
 
 def get_schema_from_capability_implementation(
     capability_type: type[IntersectBaseCapabilityImplementation],
-    capability_name: HierarchyConfig,
+    service_name: HierarchyConfig,
 ) -> dict[str, Any]:
     """The goal of this function is to be able to generate a complete schema matching the AsyncAPI spec 2.6.0 from a BaseModel class.
 
     Params:
       - capability_type - the SDK user will provide the class of their capability handler, which generates the schema
-      - capability_name - ideally, this could be scanned by the package name. Meant to be descriptive, i.e. "nionswift"
+      - service_name - ideally, this could be scanned by the package name. Meant to be descriptive, i.e. "nionswift"
 
 
     SOME NOTES ABOUT THE SCHEMA
@@ -69,9 +69,10 @@ def get_schema_from_capability_implementation(
 
     - Channel names just mimic the function names for now
     """
-    schemas, _, _, _, _ = get_schema_and_functions_from_capability_implementation(
-        capability_type,
-        capability_name,
+    cap_instance = capability_type()
+    schemas, _, _, _, _, _ = get_schema_and_functions_from_capability_implementations(
+        [cap_instance],
+        service_name,
         set(),  # assume all data handlers are configured if user is just checking their schema
     )
     return schemas

--- a/src/intersect_sdk/service.py
+++ b/src/intersect_sdk/service.py
@@ -59,7 +59,7 @@ from .service_callback_definitions import (
 )
 from .shared_callback_definitions import (
     INTERSECT_JSON_VALUE,  # noqa: TCH001 (runtime-checked annotation)
-    DirectMessageParams,  # noqa: TCH001 (runtime-checked annotation)
+    IntersectDirectMessageParams,  # noqa: TCH001 (runtime-checked annotation)
 )
 from .version import version_string
 
@@ -111,7 +111,7 @@ class IntersectService(IntersectEventObserver):
             self,
             req_id: UUID,
             req_name: str,
-            request: DirectMessageParams,
+            request: IntersectDirectMessageParams,
             response_handler: INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None = None,
         ) -> None:
             """Create an external request."""
@@ -223,13 +223,13 @@ class IntersectService(IntersectEventObserver):
         self._external_request_ctr = 0
 
         self._startup_messages: list[
-            tuple[DirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]
+            tuple[IntersectDirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]
         ] = []
         self._resend_startup_messages = True
         self._sent_startup_messages = False
 
         self._shutdown_messages: list[
-            tuple[DirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]
+            tuple[IntersectDirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]
         ] = []
 
         self._data_plane_manager = DataPlaneManager(self._hierarchy, config.data_stores)
@@ -449,7 +449,9 @@ class IntersectService(IntersectEventObserver):
 
     def add_startup_messages(
         self,
-        messages: list[tuple[DirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]],
+        messages: list[
+            tuple[IntersectDirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]
+        ],
     ) -> None:
         """Add request messages to send out to various microservices when this service starts.
 
@@ -461,7 +463,9 @@ class IntersectService(IntersectEventObserver):
 
     def add_shutdown_messages(
         self,
-        messages: list[tuple[DirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]],
+        messages: list[
+            tuple[IntersectDirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None]
+        ],
     ) -> None:
         """Add request messages to send out to various microservices on shutdown.
 
@@ -474,7 +478,7 @@ class IntersectService(IntersectEventObserver):
     @validate_call(config=ConfigDict(revalidate_instances='always'))
     def create_external_request(
         self,
-        request: DirectMessageParams,
+        request: IntersectDirectMessageParams,
         response_handler: Union[INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE, None] = None,  # noqa: UP007 (runtime checked annotation)
     ) -> UUID:
         """Create an external request that we'll send to a different Service.
@@ -715,7 +719,7 @@ class IntersectService(IntersectEventObserver):
             error_msg = f'No external request found for message:\n{message}'
             logger.warning(error_msg)
 
-    def _send_client_message(self, request_id: UUID, params: DirectMessageParams) -> bool:
+    def _send_client_message(self, request_id: UUID, params: IntersectDirectMessageParams) -> bool:
         """Send a userspace message."""
         # "params" should already be validated at this stage.
         request = GENERIC_MESSAGE_SERIALIZER.dump_json(params.payload, warnings=False)

--- a/src/intersect_sdk/service_callback_definitions.py
+++ b/src/intersect_sdk/service_callback_definitions.py
@@ -1,0 +1,16 @@
+"""Callback definitions used by Services and Capabilities.
+
+Please see shared_callback_definitions for definitions which are also used by Clients.
+"""
+
+from typing import Callable
+
+from .client_callback_definitions import INTERSECT_JSON_VALUE
+
+INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE = Callable[[INTERSECT_JSON_VALUE], None]
+"""Callback typing for the function which handles another Service's response.
+
+The function accepts one argument - the direct response from the other Service. Message metadata will not be included.
+
+This callback type should only be used on Capabilities - for client callback functions, use INTERSECT_CLIENT_RESPONSE_CALLBACK_TYPE .
+"""

--- a/src/intersect_sdk/shared_callback_definitions.py
+++ b/src/intersect_sdk/shared_callback_definitions.py
@@ -24,7 +24,7 @@ This is a simple type representation of JSON as a Python object. INTERSECT will 
 """
 
 
-class DirectMessageParams(BaseModel):
+class IntersectDirectMessageParams(BaseModel):
     """These are the public-facing properties of a message which can be sent to another Service.
 
     This object can be used by Clients, and by Services if initiating a service-to-service request.

--- a/src/intersect_sdk/shared_callback_definitions.py
+++ b/src/intersect_sdk/shared_callback_definitions.py
@@ -1,0 +1,67 @@
+"""Callback definitions shared between Services, Capabilities, and Clients."""
+
+from typing import Any, Dict, List, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Annotated, TypeAlias
+
+from .constants import SYSTEM_OF_SYSTEM_REGEX
+from .core_definitions import IntersectDataHandler, IntersectMimeType
+
+INTERSECT_JSON_VALUE: TypeAlias = Union[
+    List['INTERSECT_JSON_VALUE'],
+    Dict[str, 'INTERSECT_JSON_VALUE'],
+    str,
+    bool,
+    int,
+    float,
+    None,
+]
+"""
+This is a simple type representation of JSON as a Python object. INTERSECT will automatically deserialize service payloads into one of these types.
+
+(Pydantic has a similar type, "JsonValue", which should be used if you desire functionality beyond type hinting. This is strictly a type hint.)
+"""
+
+
+class DirectMessageParams(BaseModel):
+    """These are the public-facing properties of a message which can be sent to another Service.
+
+    This object can be used by Clients, and by Services if initiating a service-to-service request.
+    """
+
+    destination: Annotated[str, Field(pattern=SYSTEM_OF_SYSTEM_REGEX)]
+    """
+    The destination string. You'll need to know the system-of-system representation of the Service.
+
+    Note that this should match what you would see in the schema.
+    """
+
+    operation: str
+    """
+    The name of the operation you want to call from the Service - this should be represented as it is in the Service's schema.
+    """
+
+    payload: Any
+    """
+    The raw Python object you want to have serialized as the payload.
+
+    If you want to just use the service's default value for a request (assuming it has a default value for a request), you may set this as None.
+    """
+
+    content_type: IntersectMimeType = IntersectMimeType.JSON
+    """
+    The IntersectMimeType of your message. You'll want this to match with the ContentType of the function from the schema.
+
+    default: IntersectMimeType.JSON
+    """
+
+    data_handler: IntersectDataHandler = IntersectDataHandler.MESSAGE
+    """
+    The IntersectDataHandler you want to use (most people can just use IntersectDataHandler.MESSAGE here, unless your data is very large)
+
+    default: IntersectDataHandler.MESSAGE
+    """
+
+    # pydantic config
+    model_config = ConfigDict(revalidate_instances='always')

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -132,3 +132,10 @@ def test_example_3_ping_pong_events():
 
 def test_example_3_ping_pong_events_amqp():
     assert run_example_test('3_ping_pong_events_amqp') == 'ping\npong\nping\npong\n'
+
+
+def test_example_4_service_to_service():
+    assert (
+        run_example_test('4_service_to_service')
+        == 'Received Response from Service 2: Acknowledging service one text -> Kicking off the example!'
+    )

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -82,13 +82,13 @@ def test_example_2_counter():
             == 'Source: "counting-organization.counting-facility.counting-system.counting-subsystem.counting-service"'
         )
     # test operation
-    assert lines[1] == 'Operation: "start_count"'
-    assert lines[5] == 'Operation: "stop_count"'
-    assert lines[9] == 'Operation: "start_count"'
-    assert lines[13] == 'Operation: "reset_count"'
-    assert lines[17] == 'Operation: "reset_count"'
-    assert lines[21] == 'Operation: "start_count"'
-    assert lines[25] == 'Operation: "stop_count"'
+    assert lines[1] == 'Operation: "CountingExample.start_count"'
+    assert lines[5] == 'Operation: "CountingExample.stop_count"'
+    assert lines[9] == 'Operation: "CountingExample.start_count"'
+    assert lines[13] == 'Operation: "CountingExample.reset_count"'
+    assert lines[17] == 'Operation: "CountingExample.reset_count"'
+    assert lines[21] == 'Operation: "CountingExample.start_count"'
+    assert lines[25] == 'Operation: "CountingExample.stop_count"'
 
     # test payloads
     # if 'count' is within 3 steps of the subtrahend, just pass the test

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -137,5 +137,5 @@ def test_example_3_ping_pong_events_amqp():
 def test_example_4_service_to_service():
     assert (
         run_example_test('4_service_to_service')
-        == 'Received Response from Service 2: Acknowledging service one text -> Kicking off the example!'
+        == 'Received Response from Service 2: Acknowledging service one text -> Kicking off the example!\n'
     )

--- a/tests/fixtures/example_schema.json
+++ b/tests/fixtures/example_schema.json
@@ -4,7 +4,7 @@
   "info": {
     "title": "test.test.test.test.test",
     "version": "0.0.0",
-    "description": "This is an example of the overarching capability class a user creates that we want to inject into the service.\n\nWhen defining entrypoints to your capability, use the @intersect_message() annotation. Your class will need\nat least one function with this annotation. These functions REQUIRE type annotations to function properly.\nSee the @intersect_message() annotation for more information.\n\nYou can potentially extend from multiple preexisting Capabilities in this class - each Capability may have\nseveral abstract functions which would need to be implemented by the user.\n\nBeyond this, you may define your capability class however you like, including through its constructor."
+    "description": "This is an example of the overarching capability class a user creates that we want to inject into the service.\n\nWhen defining entrypoints to your capability, use the @intersect_message() annotation. Your class will need\nat least one function with this annotation. These functions REQUIRE type annotations to function properly.\nSee the @intersect_message() annotation for more information.\n\nYou can potentially extend from multiple preexisting Capabilities in this class - each Capability may have\nseveral abstract functions which would need to be implemented by the user.\n\nBeyond this, you may define your capability class however you like, including through its constructor.\n"
   },
   "defaultContentType": "application/json",
   "channels": {

--- a/tests/fixtures/example_schema.py
+++ b/tests/fixtures/example_schema.py
@@ -235,6 +235,7 @@ class DummyCapabilityImplementation(IntersectBaseCapabilityImplementation):
         which handles talking to the various INTERSECT-related backing services.
         """
         super().__init__()
+        self.capability_name = "DummyCapability"
         self._status_example = DummyStatus(
             functions_called=0,
             last_function_called='',

--- a/tests/fixtures/example_schema.py
+++ b/tests/fixtures/example_schema.py
@@ -235,7 +235,7 @@ class DummyCapabilityImplementation(IntersectBaseCapabilityImplementation):
         which handles talking to the various INTERSECT-related backing services.
         """
         super().__init__()
-        self.capability_name = "DummyCapability"
+        self.capability_name = 'DummyCapability'
         self._status_example = DummyStatus(
             functions_called=0,
             last_function_called='',

--- a/tests/integration/test_return_type_mismatch.py
+++ b/tests/integration/test_return_type_mismatch.py
@@ -44,8 +44,10 @@ class ReturnTypeMismatchCapabilityImplementation(IntersectBaseCapabilityImplemen
 
 
 def make_intersect_service() -> IntersectService:
+    capability = ReturnTypeMismatchCapabilityImplementation()
+    capability.capability_name = "ReturnTypeMismatchCapability"
     return IntersectService(
-        ReturnTypeMismatchCapabilityImplementation(),
+        [capability],
         IntersectServiceConfig(
             hierarchy=FAKE_HIERARCHY_CONFIG,
             data_stores=DataStoreConfigMap(
@@ -96,19 +98,19 @@ def test_call_user_function_with_invalid_payload():
         msg[0] = deserialize_and_validate_userspace_message(payload)
 
     message_interceptor.add_subscription_channel(
-        'msg/msg/msg/msg/msg/userspace', {userspace_msg_callback}, False
+        'msg/msg/msg/msg/msg/response', {userspace_msg_callback}, False
     )
     message_interceptor.connect()
     intersect_service.startup()
     time.sleep(1.0)
     message_interceptor.publish_message(
-        intersect_service._userspace_channel_name,
+        intersect_service._service_channel_name,
         create_userspace_message(
             source='msg.msg.msg.msg.msg',
             destination='test.test.test.test.test',
             content_type=IntersectMimeType.JSON,
             data_handler=IntersectDataHandler.MESSAGE,
-            operation_id='wrong_return_annotation',
+            operation_id='ReturnTypeMismatchCapability.wrong_return_annotation',
             # calculate_fibonacci takes in a tuple of two integers but we'll just send it one
             payload=b'2',
         ),

--- a/tests/integration/test_return_type_mismatch.py
+++ b/tests/integration/test_return_type_mismatch.py
@@ -45,7 +45,7 @@ class ReturnTypeMismatchCapabilityImplementation(IntersectBaseCapabilityImplemen
 
 def make_intersect_service() -> IntersectService:
     capability = ReturnTypeMismatchCapabilityImplementation()
-    capability.capability_name = "ReturnTypeMismatchCapability"
+    capability.capability_name = 'ReturnTypeMismatchCapability'
     return IntersectService(
         [capability],
         IntersectServiceConfig(

--- a/tests/unit/test_base_capability_implementation.py
+++ b/tests/unit/test_base_capability_implementation.py
@@ -6,8 +6,8 @@ from uuid import UUID, uuid4
 import pytest
 from intersect_sdk import (
     INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE,
-    DirectMessageParams,
     IntersectBaseCapabilityImplementation,
+    IntersectDirectMessageParams,
     IntersectEventDefinition,
     intersect_event,
     intersect_message,
@@ -23,7 +23,7 @@ class MockObserver(IntersectEventObserver):
         self.tracked_events: list[tuple[str, Any, str]] = []
         self.registered_requests: dict[
             UUID,
-            tuple[DirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None],
+            tuple[IntersectDirectMessageParams, INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None],
         ] = {}
 
     def _on_observe_event(self, event_name: str, event_value: Any, operation: str) -> None:
@@ -31,7 +31,7 @@ class MockObserver(IntersectEventObserver):
 
     def create_external_request(
         self,
-        request: DirectMessageParams,
+        request: IntersectDirectMessageParams,
         response_handler: INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None = None,
     ) -> UUID:
         request_id = uuid4()
@@ -64,7 +64,7 @@ def test_no_override():
         class BadClass3(IntersectBaseCapabilityImplementation):
             def intersect_sdk_call_service(
                 self,
-                request: DirectMessageParams,
+                request: IntersectDirectMessageParams,
                 response_handler: INTERSECT_SERVICE_RESPONSE_CALLBACK_TYPE | None = None,
             ) -> None:
                 return super().intersect_sdk_call_service(request, response_handler)
@@ -154,7 +154,7 @@ def test_functions_handle_requests():
         @intersect_message()
         def mock_request_flow(self, fake_request_value: str) -> UUID:
             return self.intersect_sdk_call_service(
-                DirectMessageParams(
+                IntersectDirectMessageParams(
                     destination='fake.fake.fake.fake.fake',
                     operation='Fake.fake',
                     payload=fake_request_value,

--- a/tests/unit/test_invalid_schema_runtime.py
+++ b/tests/unit/test_invalid_schema_runtime.py
@@ -38,5 +38,5 @@ def test_minio_not_allowed_without_config(caplog: pytest.LogCaptureFixture):
         ],
     )
     with pytest.raises(SystemExit):
-        IntersectService(cap, conf)
+        IntersectService([cap], conf)
     assert "function 'arbitrary_function' should not set response_data_type as 1" in caplog.text

--- a/tests/unit/test_schema_valid.py
+++ b/tests/unit/test_schema_valid.py
@@ -38,15 +38,10 @@ def test_schema_comparison():
 
 def test_verify_status_fn():
     dummy_cap = DummyCapabilityImplementation()
-    (
-        schema,
-        function_map,
-        _,
-        status_fn_capability,
-        status_fn_name,
-        status_type_adapter
-    ) = get_schema_and_functions_from_capability_implementations(
-        [dummy_cap], FAKE_HIERARCHY_CONFIG, set()
+    (schema, function_map, _, status_fn_capability, status_fn_name, status_type_adapter) = (
+        get_schema_and_functions_from_capability_implementations(
+            [dummy_cap], FAKE_HIERARCHY_CONFIG, set()
+        )
     )
     assert status_fn_capability is dummy_cap
     assert status_fn_name == 'get_status'
@@ -69,14 +64,30 @@ def test_verify_attributes():
         getattr(function_map['DummyCapability.verify_float_dict'].method, RESPONSE_DATA)
         == IntersectDataHandler.MESSAGE
     )
-    assert getattr(function_map['DummyCapability.verify_nested'].method, REQUEST_CONTENT) == IntersectMimeType.JSON
-    assert getattr(function_map['DummyCapability.verify_nested'].method, RESPONSE_CONTENT) == IntersectMimeType.JSON
+    assert (
+        getattr(function_map['DummyCapability.verify_nested'].method, REQUEST_CONTENT)
+        == IntersectMimeType.JSON
+    )
+    assert (
+        getattr(function_map['DummyCapability.verify_nested'].method, RESPONSE_CONTENT)
+        == IntersectMimeType.JSON
+    )
     assert getattr(function_map['DummyCapability.verify_nested'].method, STRICT_VALIDATION) is False
 
     # test non-defaults
     assert (
-        getattr(function_map['DummyCapability.verify_nested'].method, RESPONSE_DATA) == IntersectDataHandler.MINIO
+        getattr(function_map['DummyCapability.verify_nested'].method, RESPONSE_DATA)
+        == IntersectDataHandler.MINIO
     )
-    assert getattr(function_map['DummyCapability.ip4_to_ip6'].method, RESPONSE_CONTENT) == IntersectMimeType.STRING
-    assert getattr(function_map['DummyCapability.test_path'].method, REQUEST_CONTENT) == IntersectMimeType.STRING
-    assert getattr(function_map['DummyCapability.calculate_weird_algorithm'].method, STRICT_VALIDATION) is True
+    assert (
+        getattr(function_map['DummyCapability.ip4_to_ip6'].method, RESPONSE_CONTENT)
+        == IntersectMimeType.STRING
+    )
+    assert (
+        getattr(function_map['DummyCapability.test_path'].method, REQUEST_CONTENT)
+        == IntersectMimeType.STRING
+    )
+    assert (
+        getattr(function_map['DummyCapability.calculate_weird_algorithm'].method, STRICT_VALIDATION)
+        is True
+    )


### PR DESCRIPTION
From @MichaelBrim:

This changeset includes updates to enable each IntersectService instance to provide service for a set of capabilities, rather than just one. From the client perspective, the key difference is that operation names should be prepended with the advertised name of the capability providing the operation.

Also included is support for service-to-service requests, as is necessary to enable making external requests to other services/capabilities as part of the implementation of any service methods. An additional thread is used to process these external requests asynchronously from incoming request handlers.