### PR TITLE
Add DOI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Static Badge](https://img.shields.io/badge/DOI-10.11578%2Fdc.20240927.1-blue)](https://doi.org/10.11578/dc.20240927.1)
+
 # INTERSECT-SDK
 
 The INTERSECT-SDK is a framework for microservices to integrate themselves into the wider Interconnected Science Ecosystem (INTERSECT).


### PR DESCRIPTION
This adds the DOI for the INTERSECT-SDK to the README

To test:
  - The badge is visible in a good spot on the README
  - Clicking the badge will take you to the https://doi.org/<doi id> page (may not be available until DOE Code approval)