### PR TITLE
Adds badges to README for CI, PyPI, and RTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 [![Static Badge](https://img.shields.io/badge/DOI-10.11578%2Fdc.20240927.1-blue)](https://doi.org/10.11578/dc.20240927.1)
+[![CI](https://github.com/INTERSECT-SDK/python-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/INTERSECT-SDK/python-sdk/actions/workflows/ci.yml)
+[![Release to PyPi](https://github.com/INTERSECT-SDK/python-sdk/actions/workflows/publish.yml/badge.svg)](https://github.com/INTERSECT-SDK/python-sdk/actions/workflows/publish.yml)
+[![PyPI version](https://badge.fury.io/py/intersect-sdk.svg)](https://badge.fury.io/py/intersect-sdk)
+[![ReadTheDocs](https://readthedocs.org/projects/intersect-python-sdk/badge/?version=latest)](https://intersect-python-sdk.readthedocs.io/en/latest/)
 
 # INTERSECT-SDK
 


### PR DESCRIPTION
Work includes:
  - badge for CI (both CI + Release to PyPI workflows)
  - PyPI badge 
  - ReadTheDocs badge

The hope is this will help Users navigate to related links