### PR TITLE
examples: Counting add argparse to get broker info

### DIFF
--- a/examples/2_counting/broker-EXAMPLE.json
+++ b/examples/2_counting/broker-EXAMPLE.json
@@ -1,0 +1,11 @@
+{
+    "brokers": [
+        {
+            "username": "intersect_username",
+            "password": "intersect_password",
+            "port": 1883,
+            "host": "127.0.0.1",
+            "protocol": "mqtt3.1.1"
+        }
+    ]
+}

--- a/examples/2_counting/counting_client.py
+++ b/examples/2_counting/counting_client.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import time
+import argparse, textwrap
+import json
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
@@ -134,17 +136,48 @@ class SampleOrchestrator:
         return IntersectClientCallback(messages_to_send=[message])
 
 
+def parse_arguments():
+    """
+    Setup and parse command-line arguments.
+    """
+
+    p = argparse.ArgumentParser(description="Counting Example",
+                                formatter_class=argparse.RawDescriptionHelpFormatter,
+                                epilog=textwrap.dedent('''\
+             Examples:
+
+                 # Starting Service
+                python3 counting_service.py -c mybroker.json
+
+                 # Starting a Client
+                python3 counting_client.py -c mybroker.json
+         '''))
+    p.add_argument(
+        "-c", "--config",
+        type=str,
+        help="Path to broker configuration file (JSON format)."
+    )
+    return p.parse_args()
+
+
 if __name__ == '__main__':
-    from_config_file = {
-        'brokers': [
-            {
-                'username': 'intersect_username',
-                'password': 'intersect_password',
-                'port': 1883,
-                'protocol': 'mqtt3.1.1',
-            },
-        ],
-    }
+
+    args = parse_arguments()
+
+    if args.config:
+        with open(args.config, 'r') as f:
+            from_config_file = json.load(f)
+    else:
+        from_config_file = {
+            'brokers': [
+                {
+                    'username': 'intersect_username',
+                    'password': 'intersect_password',
+                    'port': 1883,
+                    'protocol': 'mqtt3.1.1',
+                },
+            ],
+        }
 
     # The counter will start after the initial message.
     # If the service is already active and counting, this may do nothing.

--- a/examples/2_counting/counting_service.py
+++ b/examples/2_counting/counting_service.py
@@ -3,6 +3,8 @@ import threading
 import time
 from dataclasses import dataclass
 from typing import Optional
+import argparse, textwrap
+import json
 
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
@@ -162,17 +164,49 @@ class CountingServiceCapabilityImplementation(IntersectBaseCapabilityImplementat
             time.sleep(1.0)
 
 
+def parse_arguments():
+    """
+    Setup and parse command-line arguments.
+    """
+
+    p = argparse.ArgumentParser(description="Counting Example",
+                                formatter_class=argparse.RawDescriptionHelpFormatter,
+                                epilog=textwrap.dedent('''\
+             Examples:
+
+                 # Starting Service
+                python3 counting_service.py -c mybroker.json
+
+                 # Starting a Client
+                python3 counting_client.py -c mybroker.json
+         '''))
+    p.add_argument(
+        "-c", "--config",
+        type=str,
+        help="Path to broker configuration file (JSON format)."
+    )
+    return p.parse_args()
+
 if __name__ == '__main__':
-    from_config_file = {
-        'brokers': [
-            {
-                'username': 'intersect_username',
-                'password': 'intersect_password',
-                'port': 1883,
-                'protocol': 'mqtt3.1.1',
-            },
-        ],
-    }
+
+    args = parse_arguments()
+
+    if args.config:
+        with open(args.config, 'r') as f:
+            from_config_file = json.load(f)
+    else:
+        # Hardcoded backup
+        from_config_file = {
+            'brokers': [
+                {
+                    'username': 'intersect_username',
+                    'password': 'intersect_password',
+                    'port': 1883,
+                    'protocol': 'mqtt3.1.1',
+                },
+            ],
+        }
+
     config = IntersectServiceConfig(
         hierarchy=HierarchyConfig(
             organization='counting-organization',

--- a/examples/2_counting_events/broker-EXAMPLE.json
+++ b/examples/2_counting_events/broker-EXAMPLE.json
@@ -1,0 +1,11 @@
+{
+    "brokers": [
+        {
+            "username": "intersect_username",
+            "password": "intersect_password",
+            "port": 1883,
+            "host": "127.0.0.1",
+            "protocol": "mqtt3.1.1"
+        }
+    ]
+}

--- a/examples/2_counting_events/counting_client.py
+++ b/examples/2_counting_events/counting_client.py
@@ -1,4 +1,6 @@
 import logging
+import argparse, textwrap
+import json
 
 from intersect_sdk import (
     INTERSECT_JSON_VALUE,
@@ -51,18 +53,48 @@ class SampleOrchestrator:
         if self.events_encountered == self.MAX_EVENTS_TO_PROCESS:
             raise Exception
 
+def parse_arguments():
+    """
+    Setup and parse command-line arguments.
+    """
+
+    p = argparse.ArgumentParser(description="Counting Example",
+                                formatter_class=argparse.RawDescriptionHelpFormatter,
+                                epilog=textwrap.dedent('''\
+             Examples:
+
+                 # Starting Service
+                python3 counting_service.py -c mybroker.json
+
+                 # Starting a Client
+                python3 counting_client.py -c mybroker.json
+         '''))
+    p.add_argument(
+        "-c", "--config",
+        type=str,
+        help="Path to broker configuration file (JSON format)."
+    )
+    return p.parse_args()
+
 
 if __name__ == '__main__':
-    from_config_file = {
-        'brokers': [
-            {
-                'username': 'intersect_username',
-                'password': 'intersect_password',
-                'port': 1883,
-                'protocol': 'mqtt3.1.1',
-            },
-        ],
-    }
+
+    args = parse_arguments()
+
+    if args.config:
+        with open(args.config, 'r') as f:
+            from_config_file = json.load(f)
+    else:
+        from_config_file = {
+            'brokers': [
+                {
+                    'username': 'intersect_username',
+                    'password': 'intersect_password',
+                    'port': 1883,
+                    'protocol': 'mqtt3.1.1',
+                },
+            ],
+        }
 
     # start listening to events from the counting service
     config = IntersectClientConfig(

--- a/examples/2_counting_events/counting_service.py
+++ b/examples/2_counting_events/counting_service.py
@@ -1,6 +1,8 @@
 import logging
 import threading
 import time
+import argparse, textwrap
+import json
 
 from intersect_sdk import (
     HierarchyConfig,
@@ -52,18 +54,49 @@ class CountingServiceCapabilityImplementation(IntersectBaseCapabilityImplementat
             self.counter *= 3
             self.intersect_sdk_emit_event('increment_counter', self.counter)
 
+def parse_arguments():
+    """
+    Setup and parse command-line arguments.
+    """
+
+    p = argparse.ArgumentParser(description="Counting Example",
+                                formatter_class=argparse.RawDescriptionHelpFormatter,
+                                epilog=textwrap.dedent('''\
+             Examples:
+
+                 # Starting Service
+                python3 counting_service.py -c mybroker.json
+
+                 # Starting a Client
+                python3 counting_client.py -c mybroker.json
+         '''))
+    p.add_argument(
+        "-c", "--config",
+        type=str,
+        help="Path to broker configuration file (JSON format)."
+    )
+    return p.parse_args()
+
 
 if __name__ == '__main__':
-    from_config_file = {
-        'brokers': [
-            {
-                'username': 'intersect_username',
-                'password': 'intersect_password',
-                'port': 1883,
-                'protocol': 'mqtt3.1.1',
-            },
-        ],
-    }
+
+    args = parse_arguments()
+
+    if args.config:
+        with open(args.config, 'r') as f:
+            from_config_file = json.load(f)
+    else:
+        from_config_file = {
+            'brokers': [
+                {
+                    'username': 'intersect_username',
+                    'password': 'intersect_password',
+                    'port': 1883,
+                    'protocol': 'mqtt3.1.1',
+                },
+            ],
+        }
+
     config = IntersectServiceConfig(
         hierarchy=HierarchyConfig(
             organization='counting-organization',


### PR DESCRIPTION
Adds ability to pass a file with broker configuration so do not have to hardcode details in file.

Configuration file (JSON format):

  ```
  {
      "brokers": [
          {
              "username": "intersect_username",
              "password": "intersect_password",
              "port": 1883,
              "host": "127.0.0.1",
              "protocol": "mqtt3.1.1"
          }
      ]
  }
  ```